### PR TITLE
nng: drop obsolete clippy::empty_enum allow

### DIFF
--- a/nng/src/lib.rs
+++ b/nng/src/lib.rs
@@ -147,7 +147,6 @@
 // would like that, but this library is a safe wrapper around a Bindgen-based binding of a C
 // library, which means the types are a little bit up-in-the-air.
 #![allow(clippy::cast_sign_loss)]
-#![allow(clippy::empty_enum)] // Revisit after RFC1861 and RFC1216.
 #![allow(clippy::cargo_common_metadata)] // Can't control this.
 #![allow(clippy::module_name_repetitions)] // Doesn't recognize public re-exports.
 #![allow(clippy::cast_possible_wrap)]


### PR DESCRIPTION
Remove the `#![allow(clippy::empty_enum)]` suppression from `nng/src/lib.rs`.

The comment referenced RFC 1861 (extern types) and RFC 1216 (C-compatible enums), both of which have long since been resolved. The lint no longer fires on this codebase, making the allow unnecessary and event produces a clippy warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality configurations.

---

*Note: This release contains no user-facing changes or new features.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->