### PR TITLE
nng: bump version to 2.0.0-v2pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "nng"
-version = "1.0.1"
+version = "2.0.0-v2pre.1"
 dependencies = [
  "log",
  "nng-sys 0.3.0+1.11.0",

--- a/nng/Cargo.toml
+++ b/nng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nng"
-version = "1.0.1"
+version = "2.0.0-v2pre.1"
 authors = ["Nathan Kent <nate@nkent.net>"]
 
 description = "A safe wrapper for NNG (Nanomsg v2)"


### PR DESCRIPTION
Bump the nng crate from `1.0.1` to `2.0.0-v2pre.1` to fix `cargo-semver-checks` failures in CI.

The crate has accumulated breaking API changes since the published `1.0.1` release, and a major version bump is the only way to signal this under `semver`.

The pre-release tag `v2pre` indicates that the crate is expected to undergo further breaking changes as it migrates to the NNG v2 API in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 2.0.0-v2pre.1 (pre-release).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->