### PR TITLE
anng: lower "wait cancelled" log level to trace

### DIFF
--- a/anng/src/aio.rs
+++ b/anng/src/aio.rs
@@ -108,7 +108,7 @@ impl Aio {
                 // we have to do that so that we can correctly handle the contained message, if
                 // any. note that we _don't_ use nng_aio_stop, because that permanently stops
                 // the AIO and disallows future operations (returns NNG_ESTOPPED).
-                tracing::warn!("wait cancelled");
+                tracing::trace!("wait cancelled");
                 crate::block_in_place(|| unsafe {
                     nng_sys::nng_aio_cancel(self.0.aio.as_ptr());
                     nng_sys::nng_aio_wait(self.0.aio.as_ptr());


### PR DESCRIPTION
The `CancellationGuard` fires whenever an AIO future is dropped before completion, which is the normal way structured concurrency (e.g., `tokio::select!`, timeouts) cancels in-flight operations. This is an expected control-flow path, not an error condition, so logging it at warn was too noisy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging level for asynchronous operation cancellation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->