### PR TITLE
anng: add REQ0 resend time and tick socket options

### DIFF
--- a/anng/src/lib.rs
+++ b/anng/src/lib.rs
@@ -108,6 +108,7 @@ mod aio;
 mod context;
 pub mod init;
 mod message;
+pub(crate) mod options;
 pub mod pipes;
 pub mod protocols;
 

--- a/anng/src/lib.rs
+++ b/anng/src/lib.rs
@@ -244,7 +244,7 @@ impl<Protocol> fmt::Debug for Socket<Protocol> {
 /// `nng_aio_cancel` and waiting for operations to fully terminate.
 pub struct ContextfulSocket<'socket, Protocol> {
     aio: Aio,
-    context: Context<'socket, Protocol>,
+    pub(crate) context: Context<'socket, Protocol>,
 }
 
 // manual impl to avoid Protocol: Debug bound

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -43,7 +43,7 @@ pub(crate) fn set_socket_ms(
     let option_cstr = CStr::from_bytes_with_nul(option)
         .unwrap_or_else(|e| panic!("option name is not a valid C string: {e}"));
     // SAFETY: caller guarantees the socket is valid and supports the named option;
-    //         `option_cstr` is arount `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
+    //         `option_cstr` is built from a `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
     let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option_cstr.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_set_ms_errno(errno, label, "nng_socket_set_ms");

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -19,7 +19,8 @@ use core::{
     ffi::{CStr, c_int},
     time::Duration,
 };
-use nng_sys::ErrorCode;
+use nng_sys::{ErrorCode, ErrorKind};
+use std::io;
 
 /// Sets a `nng_duration` (ms) option on a socket, panicking on any NNG-reported error.
 ///
@@ -37,8 +38,8 @@ pub(crate) fn set_socket_ms(
     socket: nng_sys::nng_socket,
     option: &'static [u8],
     duration: Duration,
-    label: &'static str,
-) {
+    label: &str,
+) -> io::Result<()> {
     let ms = duration_to_nng_ms(duration, label);
     let option_cstr = CStr::from_bytes_with_nul(option)
         .unwrap_or_else(|e| panic!("option name is not a valid C string: {e}"));
@@ -46,7 +47,7 @@ pub(crate) fn set_socket_ms(
     //         `option_cstr` is built from a `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
     let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option_cstr.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
-    check_set_ms_errno(errno, label, "nng_socket_set_ms");
+    check_map_set_ms_errno(errno, label, "nng_socket_set_ms")
 }
 
 /// Sets a `nng_duration` (ms) option on a context. See [`set_socket_ms`] for invariants.
@@ -54,8 +55,8 @@ pub(crate) fn set_ctx_ms(
     ctx: nng_sys::nng_ctx,
     option: &'static [u8],
     duration: Duration,
-    label: &'static str,
-) {
+    label: &str,
+) -> io::Result<()> {
     let ms = duration_to_nng_ms(duration, label);
     let option_cstr = CStr::from_bytes_with_nul(option)
         .unwrap_or_else(|e| panic!("option name is not a valid C string: {e}"));
@@ -63,10 +64,10 @@ pub(crate) fn set_ctx_ms(
     //         `option_str` is built from a `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
     let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx, option_cstr.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
-    check_set_ms_errno(errno, label, "nng_ctx_set_ms");
+    check_map_set_ms_errno(errno, label, "nng_ctx_set_ms")
 }
 
-fn duration_to_nng_ms(duration: Duration, label: &'static str) -> c_int {
+fn duration_to_nng_ms(duration: Duration, label: &str) -> c_int {
     let ms = duration.as_millis();
     if ms > i32::MAX as u128 {
         panic!("{label} is too large: {duration:?}");
@@ -74,29 +75,41 @@ fn duration_to_nng_ms(duration: Duration, label: &'static str) -> c_int {
     ms as c_int
 }
 
-fn check_set_ms_errno(errno: u32, label: &'static str, fn_name: &str) {
+fn check_map_set_ms_errno(errno: u32, label: &str, fn_name: &str) -> io::Result<()> {
     match errno {
-        0 => {}
+        0 => Ok(()),
         e if e == ErrorCode::ECLOSED as u32 => {
-            unreachable!("{fn_name}({label}): NNG returned ECLOSED ({errno}) unexpectedly");
+            unreachable!("{fn_name}({label}): NNG returned ECLOSED on a borrowed, live handle");
         }
         e if e == ErrorCode::EINVAL as u32 => {
             unreachable!(
-                "{fn_name}({label}): NNG rejected duration as invalid via EINVAL ({errno})"
+                "{fn_name}({label}): NNG returned EINVAL despite a pre-validated duration and \
+                 a static option name"
             );
         }
         e if e == ErrorCode::ENOTSUP as u32 => {
             unreachable!(
-                "{fn_name}({label}): option not supported on this protocol/scope — NNG returned ENOTSUP ({errno})"
+                "{fn_name}({label}): NNG returned ENOTSUP — option/protocol pairing is wrong \
+                 in the calling protocol module"
             );
         }
         e if e == ErrorCode::EREADONLY as u32 => {
             unreachable!(
-                "{fn_name}({label}): option is read-only — NNG returned EREADONLY ({errno})"
+                "{fn_name}({label}): NNG returned EREADONLY — a read-only ms option was routed \
+                 through a helper that assumes always-mutable options"
             );
         }
+        e if e == ErrorCode::ESTATE as u32 => {
+            Err(io::Error::other(ErrorKind::NngError(ErrorCode::ESTATE)))
+        }
         _ => {
-            unreachable!("{fn_name}({label}) returned undocumented errno {errno}");
+            // Any other errno is undocumented for `nng_socket_set_ms` / `nng_ctx_set_ms`.
+            // Most likely cause: NNG added a new failure mode in a newer release. Re-check the
+            // current `nng_*_set_ms` docs and add an explicit arm above for the new errno.
+            unreachable!(
+                "{fn_name}({label}) returned errno {errno}, which is not documented for \
+                 `nng_*_set_ms` — NNG behaviour likely changed; update this match"
+            );
         }
     }
 }

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -1,0 +1,127 @@
+//! Internal helpers for setting NNG options on sockets, contexts, dialers, and listeners.
+//!
+//! Each helper centralizes the bounds check on the value, the unsafe FFI call, and the
+//! `unreachable!` arms for errnos that NNG documents but that callers in this crate are
+//! statically responsible for never triggering. Callers in the protocol modules pass the
+//! `nng_sys::NNG_OPT_*` byte slice and a human-readable label.
+//!
+//! ## Future maintenance
+//!
+//! Today only `_set_ms` exists, so we have one pair (`set_socket_ms`, `set_ctx_ms`) that share
+//! ~90% of their bodies. When a second value type lands (`_set_int`, `_set_bool`, `_set_size`,
+//! `_set_string`), do **not** keep copy-pasting: that's the moment to extract a private trait
+//! over the handle (e.g. `trait OptionTarget { fn set_ms(...); fn set_int(...); ... }`) with
+//! impls for `nng_socket` and `nng_ctx`, and rewrite the helpers as a single generic over the
+//! trait. Doing it now (with one value type) would be premature; doing it after the third would
+//! be painful.
+
+use core::{
+    ffi::{CStr, c_int},
+    time::Duration,
+};
+use nng_sys::ErrorCode;
+
+/// Sets a `nng_duration` (ms) option on a socket, panicking on any NNG-reported error.
+///
+/// Every `nng_socket_set_ms` failure is a programming error at this layer (closed handle, unknown
+/// option, read-only option, invalid duration, or any errno NNG hasn't documented). The caller is
+/// statically responsible for pairing a valid socket with a valid option supported by the
+/// socket's protocol; the `label` argument is a human-readable name used in the panic messages
+/// (e.g. `"resend time"`).
+///
+/// Note: NNG defines sentinel duration values (`NNG_DURATION_INFINITE`, `NNG_DURATION_DEFAULT`)
+/// as negative numbers. They cannot be expressed via [`Duration`] and are deliberately not
+/// supported by this helper — protocol-level helpers should expose them through their own API
+/// surface if needed.
+pub(crate) fn set_socket_ms(
+    socket: nng_sys::nng_socket,
+    option: &'static [u8],
+    duration: Duration,
+    label: &'static str,
+) {
+    let ms = duration_to_nng_ms(duration, label);
+    let option_cstr = CStr::from_bytes_with_nul(option)
+        .unwrap_or_else(|e| panic!("option name is not a valid C string: {e}"));
+    // SAFETY: caller guarantees the socket is valid and supports the named option;
+    //         `option_cstr` is arount `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
+    let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option_cstr.as_ptr(), ms) };
+    let errno = u32::try_from(raw_errno).expect("errno is never negative");
+    check_set_ms_errno(errno, label, "nng_socket_set_ms");
+}
+
+/// Sets a `nng_duration` (ms) option on a context. See [`set_socket_ms`] for invariants.
+pub(crate) fn set_ctx_ms(
+    ctx: nng_sys::nng_ctx,
+    option: &'static [u8],
+    duration: Duration,
+    label: &'static str,
+) {
+    let ms = duration_to_nng_ms(duration, label);
+    let option_cstr = CStr::from_bytes_with_nul(option)
+        .unwrap_or_else(|e| panic!("option name is not a valid C string: {e}"));
+    // SAFETY: caller guarantees the context is valid and supports the named option;
+    //         `option` is arount `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
+    let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx, option_cstr.as_ptr(), ms) };
+    let errno = u32::try_from(raw_errno).expect("errno is never negative");
+    check_set_ms_errno(errno, label, "nng_ctx_set_ms");
+}
+
+fn duration_to_nng_ms(duration: Duration, label: &'static str) -> c_int {
+    let ms = duration.as_millis();
+    if ms > i32::MAX as u128 {
+        panic!("{label} is too large: {duration:?}");
+    }
+    ms as c_int
+}
+
+fn check_set_ms_errno(errno: u32, label: &'static str, fn_name: &str) {
+    match errno {
+        0 => {}
+        e if e == ErrorCode::ECLOSED as u32 => {
+            unreachable!("{fn_name}({label}): NNG returned ECLOSED ({errno}) unexpectedly");
+        }
+        e if e == ErrorCode::EINVAL as u32 => {
+            unreachable!(
+                "{fn_name}({label}): NNG rejected duration as invalid via EINVAL ({errno})"
+            );
+        }
+        e if e == ErrorCode::ENOTSUP as u32 => {
+            unreachable!(
+                "{fn_name}({label}): option not supported on this protocol/scope — NNG returned ENOTSUP ({errno})"
+            );
+        }
+        e if e == ErrorCode::EREADONLY as u32 => {
+            unreachable!(
+                "{fn_name}({label}): option is read-only — NNG returned EREADONLY ({errno})"
+            );
+        }
+        _ => {
+            unreachable!("{fn_name}({label}) returned undocumented errno {errno}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_to_nng_ms_accepts_zero() {
+        assert_eq!(duration_to_nng_ms(Duration::ZERO, "test"), 0);
+    }
+
+    #[test]
+    fn duration_to_nng_ms_accepts_max_i32() {
+        assert_eq!(
+            duration_to_nng_ms(Duration::from_millis(i32::MAX as u64), "test"),
+            i32::MAX,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "test is too large")]
+    fn duration_to_nng_ms_rejects_overflow() {
+        // Duration::MAX is the worst case a caller can hand us; it must be caught.
+        duration_to_nng_ms(Duration::MAX, "test");
+    }
+}

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -60,7 +60,7 @@ pub(crate) fn set_ctx_ms(
     let option_cstr = CStr::from_bytes_with_nul(option)
         .unwrap_or_else(|e| panic!("option name is not a valid C string: {e}"));
     // SAFETY: caller guarantees the context is valid and supports the named option;
-    //         `option` is arount `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
+    //         `option_str` is built from a `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
     let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx, option_cstr.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_set_ms_errno(errno, label, "nng_ctx_set_ms");

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -34,16 +34,18 @@ use std::io;
 /// as negative numbers. They cannot be expressed via [`Duration`] and are deliberately not
 /// supported by this helper — protocol-level helpers should expose them through their own API
 /// surface if needed.
-pub(crate) fn set_socket_ms(
-    socket: nng_sys::nng_socket,
+pub(crate) fn set_socket_ms<Protocol>(
+    socket: &crate::Socket<Protocol>,
     option: &CStr,
     duration: Duration,
     label: &str,
 ) -> io::Result<()> {
     let ms = duration_to_nng_ms(duration, label);
     // SAFETY: `option` is a borrowed `&CStr` pointing to valid, NUL-terminated memory.
-    //         The `socket` handle is a safe u32 identifier verified internally by NNG.
-    let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option.as_ptr(), ms) };
+    //         The handle comes from a borrowed `&Socket`, so the socket is statically
+    //         guaranteed to be live for the duration of this call (it cannot be closed
+    //         until its `Drop`), which is what lets the `ECLOSED` arm stay `unreachable!`.
+    let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket.id(), option.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_map_set_ms_errno(errno, label, "nng_socket_set_ms")
 }
@@ -55,32 +57,36 @@ pub(crate) fn set_socket_ms(
 /// from "disable the duration-driven behaviour". `None` (and `Some(Duration::ZERO)`) map to
 /// `NNG_DURATION_INFINITE`, which NNG treats as "no timer"; a positive `Some(duration)` maps to
 /// that many milliseconds. See [`set_socket_ms`] for the shared invariants and panic conditions.
-pub(crate) fn set_socket_ms_opt(
-    socket: nng_sys::nng_socket,
+pub(crate) fn set_socket_ms_opt<Protocol>(
+    socket: &crate::Socket<Protocol>,
     option: &CStr,
     duration: Option<Duration>,
     label: &str,
 ) -> io::Result<()> {
     let ms = duration_opt_to_nng_ms(duration, label);
     // SAFETY: `option` is a borrowed `&CStr` pointing to valid, NUL-terminated memory.
-    //         The `socket` handle is a safe u32 identifier verified internally by NNG.
-    let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option.as_ptr(), ms) };
+    //         The handle comes from a borrowed `&Socket`, so the socket is statically
+    //         guaranteed to be live for the duration of this call (see [`set_socket_ms`]).
+    let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket.id(), option.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_map_set_ms_errno(errno, label, "nng_socket_set_ms")
 }
 
 /// Sets a `nng_duration` (ms) option on a context, mapping "no duration" to the NNG
 /// `NNG_DURATION_INFINITE` sentinel. See [`set_socket_ms_opt`] for semantics.
-pub(crate) fn set_ctx_ms_opt(
-    ctx: nng_sys::nng_ctx,
+pub(crate) fn set_ctx_ms_opt<Protocol>(
+    ctx: &mut crate::context::Context<'_, Protocol>,
     option: &CStr,
     duration: Option<Duration>,
     label: &str,
 ) -> io::Result<()> {
     let ms = duration_opt_to_nng_ms(duration, label);
     // SAFETY: `option` is a borrowed `&CStr` pointing to valid, NUL-terminated memory.
-    //         The `ctx` handle is a safe u32 identifier verified internally by NNG.
-    let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx, option.as_ptr(), ms) };
+    //         The handle comes from a borrowed `&mut Context`, so the context is statically
+    //         guaranteed to be live and exclusively held for the duration of this call (it
+    //         cannot be closed until its `Drop`), which is what lets the `ECLOSED` arm stay
+    //         `unreachable!`.
+    let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx.id(), option.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_map_set_ms_errno(errno, label, "nng_ctx_set_ms")
 }

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -54,9 +54,10 @@ pub(crate) fn set_socket_ms<Protocol>(
 /// `NNG_DURATION_INFINITE` sentinel.
 ///
 /// This is the [`set_socket_ms`] variant for options that distinguish "set a finite duration"
-/// from "disable the duration-driven behaviour". `None` (and `Some(Duration::ZERO)`) map to
-/// `NNG_DURATION_INFINITE`, which NNG treats as "no timer"; a positive `Some(duration)` maps to
-/// that many milliseconds. See [`set_socket_ms`] for the shared invariants and panic conditions.
+/// from "disable the duration-driven behaviour". `None` maps to `NNG_DURATION_INFINITE`, which
+/// NNG treats as "no timer"; `Some(duration)` is forwarded as-is (including `Duration::ZERO`,
+/// which NNG interprets as a zero-length timer). See [`set_socket_ms`] for the shared invariants
+/// and panic conditions.
 pub(crate) fn set_socket_ms_opt<Protocol>(
     socket: &crate::Socket<Protocol>,
     option: &CStr,
@@ -107,18 +108,16 @@ fn duration_to_nng_ms(duration: Duration, label: &str) -> c_int {
     ms as c_int
 }
 
-/// Converts an optional duration to a `nng_duration`, mapping the "disabled" cases to
+/// Converts an optional duration to a `nng_duration`, mapping [`None`] to
 /// `NNG_DURATION_INFINITE`.
 ///
 /// `None` means "disable the duration-driven behaviour" and maps to `NNG_DURATION_INFINITE`.
-/// `Some(Duration::ZERO)` is treated the same way: a literal `0` would tell NNG to act with a
-/// zero-length timer, which is almost never what a caller asking for "zero" actually wants, so we
-/// fold it into the infinite sentinel as well. Any positive duration is bounds-checked and
-/// converted to milliseconds by [`duration_to_nng_ms`].
+/// `Some(duration)` is bounds-checked and converted to milliseconds by [`duration_to_nng_ms`];
+/// `Some(Duration::ZERO)` is forwarded as a literal `0`, which NNG treats as a zero-length timer.
 fn duration_opt_to_nng_ms(duration: Option<Duration>, label: &str) -> c_int {
     match duration {
-        None | Some(Duration::ZERO) => nng_sys::NNG_DURATION_INFINITE,
         Some(duration) => duration_to_nng_ms(duration, label),
+        None => nng_sys::NNG_DURATION_INFINITE,
     }
 }
 
@@ -194,11 +193,8 @@ mod tests {
     }
 
     #[test]
-    fn duration_opt_zero_maps_to_infinite() {
-        assert_eq!(
-            duration_opt_to_nng_ms(Some(Duration::ZERO), "test"),
-            nng_sys::NNG_DURATION_INFINITE,
-        );
+    fn duration_opt_zero_maps_to_zero() {
+        assert_eq!(duration_opt_to_nng_ms(Some(Duration::ZERO), "test"), 0);
     }
 
     #[test]

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -7,13 +7,13 @@
 //!
 //! ## Future maintenance
 //!
-//! Today only `_set_ms` exists, so we have one pair (`set_socket_ms`, `set_ctx_ms`) that share
-//! ~90% of their bodies. When a second value type lands (`_set_int`, `_set_bool`, `_set_size`,
-//! `_set_string`), do **not** keep copy-pasting: that's the moment to extract a private trait
-//! over the handle (e.g. `trait OptionTarget { fn set_ms(...); fn set_int(...); ... }`) with
-//! impls for `nng_socket` and `nng_ctx`, and rewrite the helpers as a single generic over the
-//! trait. Doing it now (with one value type) would be premature; doing it after the third would
-//! be painful.
+//! Today only `_set_ms` exists, in plain (`set_socket_ms`) and optional/infinite-aware
+//! (`set_socket_ms_opt`, `set_ctx_ms_opt`) flavours that share most of their bodies. When a
+//! second value type lands (`_set_int`, `_set_bool`, `_set_size`, `_set_string`), do **not** keep
+//! copy-pasting: that's the moment to extract a private trait over the handle (e.g. `trait
+//! OptionTarget { fn set_ms(...); fn set_int(...); ... }`) with impls for `nng_socket` and
+//! `nng_ctx`, and rewrite the helpers as a single generic over the trait. Doing it now (with one
+//! value type) would be premature; doing it after the third would be painful.
 
 use core::{
     ffi::{CStr, c_int},
@@ -48,14 +48,36 @@ pub(crate) fn set_socket_ms(
     check_map_set_ms_errno(errno, label, "nng_socket_set_ms")
 }
 
-/// Sets a `nng_duration` (ms) option on a context. See [`set_socket_ms`] for invariants.
-pub(crate) fn set_ctx_ms(
-    ctx: nng_sys::nng_ctx,
+/// Sets a `nng_duration` (ms) option on a socket, mapping "no duration" to the NNG
+/// `NNG_DURATION_INFINITE` sentinel.
+///
+/// This is the [`set_socket_ms`] variant for options that distinguish "set a finite duration"
+/// from "disable the duration-driven behaviour". `None` (and `Some(Duration::ZERO)`) map to
+/// `NNG_DURATION_INFINITE`, which NNG treats as "no timer"; a positive `Some(duration)` maps to
+/// that many milliseconds. See [`set_socket_ms`] for the shared invariants and panic conditions.
+pub(crate) fn set_socket_ms_opt(
+    socket: nng_sys::nng_socket,
     option: &CStr,
-    duration: Duration,
+    duration: Option<Duration>,
     label: &str,
 ) -> io::Result<()> {
-    let ms = duration_to_nng_ms(duration, label);
+    let ms = duration_opt_to_nng_ms(duration, label);
+    // SAFETY: caller guarantees the socket is valid and supports the named option;
+    //         `option` is a borrowed `&CStr`, so its `.as_ptr()` is valid for the FFI call.
+    let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option.as_ptr(), ms) };
+    let errno = u32::try_from(raw_errno).expect("errno is never negative");
+    check_map_set_ms_errno(errno, label, "nng_socket_set_ms")
+}
+
+/// Sets a `nng_duration` (ms) option on a context, mapping "no duration" to the NNG
+/// `NNG_DURATION_INFINITE` sentinel. See [`set_socket_ms_opt`] for semantics.
+pub(crate) fn set_ctx_ms_opt(
+    ctx: nng_sys::nng_ctx,
+    option: &CStr,
+    duration: Option<Duration>,
+    label: &str,
+) -> io::Result<()> {
+    let ms = duration_opt_to_nng_ms(duration, label);
     // SAFETY: caller guarantees the context is valid and supports the named option;
     //         `option` is a borrowed `&CStr`, so its `.as_ptr()` is valid for the FFI call.
     let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx, option.as_ptr(), ms) };
@@ -77,6 +99,21 @@ fn duration_to_nng_ms(duration: Duration, label: &str) -> c_int {
         panic!("{label} is too large: {duration:?}");
     }
     ms as c_int
+}
+
+/// Converts an optional duration to a `nng_duration`, mapping the "disabled" cases to
+/// `NNG_DURATION_INFINITE`.
+///
+/// `None` means "disable the duration-driven behaviour" and maps to `NNG_DURATION_INFINITE`.
+/// `Some(Duration::ZERO)` is treated the same way: a literal `0` would tell NNG to act with a
+/// zero-length timer, which is almost never what a caller asking for "zero" actually wants, so we
+/// fold it into the infinite sentinel as well. Any positive duration is bounds-checked and
+/// converted to milliseconds by [`duration_to_nng_ms`].
+fn duration_opt_to_nng_ms(duration: Option<Duration>, label: &str) -> c_int {
+    match duration {
+        None | Some(Duration::ZERO) => nng_sys::NNG_DURATION_INFINITE,
+        Some(duration) => duration_to_nng_ms(duration, label),
+    }
 }
 
 fn check_map_set_ms_errno(errno: u32, label: &str, fn_name: &str) -> io::Result<()> {
@@ -140,5 +177,35 @@ mod tests {
     fn duration_to_nng_ms_rejects_overflow() {
         // Duration::MAX is the worst case a caller can hand us; it must be caught.
         duration_to_nng_ms(Duration::MAX, "test");
+    }
+
+    #[test]
+    fn duration_opt_none_maps_to_infinite() {
+        assert_eq!(
+            duration_opt_to_nng_ms(None, "test"),
+            nng_sys::NNG_DURATION_INFINITE,
+        );
+    }
+
+    #[test]
+    fn duration_opt_zero_maps_to_infinite() {
+        assert_eq!(
+            duration_opt_to_nng_ms(Some(Duration::ZERO), "test"),
+            nng_sys::NNG_DURATION_INFINITE,
+        );
+    }
+
+    #[test]
+    fn duration_opt_positive_maps_to_ms() {
+        assert_eq!(
+            duration_opt_to_nng_ms(Some(Duration::from_millis(50)), "test"),
+            50,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "test is too large")]
+    fn duration_opt_rejects_overflow() {
+        duration_opt_to_nng_ms(Some(Duration::MAX), "test");
     }
 }

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -41,8 +41,8 @@ pub(crate) fn set_socket_ms(
     label: &str,
 ) -> io::Result<()> {
     let ms = duration_to_nng_ms(duration, label);
-    // SAFETY: caller guarantees the socket is valid and supports the named option;
-    //         `option` is a borrowed `&CStr`, so its `.as_ptr()` is valid for the FFI call.
+    // SAFETY: `option` is a borrowed `&CStr` pointing to valid, NUL-terminated memory.
+    //         The `socket` handle is a safe u32 identifier verified internally by NNG.
     let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_map_set_ms_errno(errno, label, "nng_socket_set_ms")
@@ -62,8 +62,8 @@ pub(crate) fn set_socket_ms_opt(
     label: &str,
 ) -> io::Result<()> {
     let ms = duration_opt_to_nng_ms(duration, label);
-    // SAFETY: caller guarantees the socket is valid and supports the named option;
-    //         `option` is a borrowed `&CStr`, so its `.as_ptr()` is valid for the FFI call.
+    // SAFETY: `option` is a borrowed `&CStr` pointing to valid, NUL-terminated memory.
+    //         The `socket` handle is a safe u32 identifier verified internally by NNG.
     let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_map_set_ms_errno(errno, label, "nng_socket_set_ms")
@@ -78,8 +78,8 @@ pub(crate) fn set_ctx_ms_opt(
     label: &str,
 ) -> io::Result<()> {
     let ms = duration_opt_to_nng_ms(duration, label);
-    // SAFETY: caller guarantees the context is valid and supports the named option;
-    //         `option` is a borrowed `&CStr`, so its `.as_ptr()` is valid for the FFI call.
+    // SAFETY: `option` is a borrowed `&CStr` pointing to valid, NUL-terminated memory.
+    //         The `ctx` handle is a safe u32 identifier verified internally by NNG.
     let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx, option.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_map_set_ms_errno(errno, label, "nng_ctx_set_ms")

--- a/anng/src/options.rs
+++ b/anng/src/options.rs
@@ -36,16 +36,14 @@ use std::io;
 /// surface if needed.
 pub(crate) fn set_socket_ms(
     socket: nng_sys::nng_socket,
-    option: &'static [u8],
+    option: &CStr,
     duration: Duration,
     label: &str,
 ) -> io::Result<()> {
     let ms = duration_to_nng_ms(duration, label);
-    let option_cstr = CStr::from_bytes_with_nul(option)
-        .unwrap_or_else(|e| panic!("option name is not a valid C string: {e}"));
     // SAFETY: caller guarantees the socket is valid and supports the named option;
-    //         `option_cstr` is built from a `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
-    let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option_cstr.as_ptr(), ms) };
+    //         `option` is a borrowed `&CStr`, so its `.as_ptr()` is valid for the FFI call.
+    let raw_errno = unsafe { nng_sys::nng_socket_set_ms(socket, option.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_map_set_ms_errno(errno, label, "nng_socket_set_ms")
 }
@@ -53,18 +51,24 @@ pub(crate) fn set_socket_ms(
 /// Sets a `nng_duration` (ms) option on a context. See [`set_socket_ms`] for invariants.
 pub(crate) fn set_ctx_ms(
     ctx: nng_sys::nng_ctx,
-    option: &'static [u8],
+    option: &CStr,
     duration: Duration,
     label: &str,
 ) -> io::Result<()> {
     let ms = duration_to_nng_ms(duration, label);
-    let option_cstr = CStr::from_bytes_with_nul(option)
-        .unwrap_or_else(|e| panic!("option name is not a valid C string: {e}"));
     // SAFETY: caller guarantees the context is valid and supports the named option;
-    //         `option_str` is built from a `&'static [u8]`, so its `.as_ptr()` is valid for the FFI call.
-    let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx, option_cstr.as_ptr(), ms) };
+    //         `option` is a borrowed `&CStr`, so its `.as_ptr()` is valid for the FFI call.
+    let raw_errno = unsafe { nng_sys::nng_ctx_set_ms(ctx, option.as_ptr(), ms) };
     let errno = u32::try_from(raw_errno).expect("errno is never negative");
     check_map_set_ms_errno(errno, label, "nng_ctx_set_ms")
+}
+
+/// Wraps a nul-terminated `nng_sys::NNG_OPT_*` byte constant as a `&'static CStr`.
+pub(crate) const fn opt(name: &'static [u8]) -> &'static CStr {
+    match CStr::from_bytes_with_nul(name) {
+        Ok(c) => c,
+        Err(_) => panic!("nng option name is not a valid C string"),
+    }
 }
 
 fn duration_to_nng_ms(duration: Duration, label: &str) -> c_int {

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -92,7 +92,7 @@
 
 use super::SupportsContext;
 use crate::{ContextfulSocket, Socket, aio::AioError, message::Message};
-use core::ffi::CStr;
+use core::{ffi::CStr, time::Duration};
 use std::{future::Future, io};
 
 /// Request socket type for the client side of Request/Reply communication.
@@ -172,7 +172,101 @@ impl Req0 {
     }
 }
 
+impl Socket<Req0> {
+    /// Sets how long the socket waits for a reply before re-sending the request.
+    ///
+    /// REQ0 retransmits an outstanding request whenever this duration elapses without a reply,
+    /// guarding against lost requests, dropped replies, or replier restarts. The default is 60
+    /// seconds; resend is checked at the [tick interval](Self::set_resend_tick), so the actual
+    /// retransmit can lag the nominal timeout by up to one tick. Wraps NNG's
+    /// [`NNG_OPT_REQ_RESENDTIME`] option.
+    ///
+    /// [`NNG_OPT_REQ_RESENDTIME`]: nng_sys::NNG_OPT_REQ_RESENDTIME
+    ///
+    /// Passing [`Duration::ZERO`] disables retransmission entirely: the request is sent once
+    /// and the receive future stays pending until either a reply arrives or the socket is
+    /// closed. NNG's `NNG_DURATION_INFINITE` sentinel has the same effect but is negative and
+    /// cannot be expressed as a [`Duration`] — use `Duration::ZERO` to get that behaviour.
+    ///
+    /// This is the socket-wide value. Each context snapshots it at creation time, so changing
+    /// it here only affects contexts created afterwards; pre-existing contexts keep whatever
+    /// value they were created with (and can override per-context via
+    /// [`ContextfulSocket::set_resend_time`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `timeout` exceeds `i32::MAX` milliseconds.
+    pub fn set_resend_time(&self, timeout: Duration) {
+        crate::options::set_socket_ms(
+            self.id(),
+            nng_sys::NNG_OPT_REQ_RESENDTIME,
+            timeout,
+            "resend time",
+        );
+    }
+
+    /// Sets the granularity of the [resend time](Self::set_resend_time) timer.
+    ///
+    /// REQ0 does not arm a per-request timer; it wakes on a fixed tick and re-sends every
+    /// pending request whose resend time has elapsed since the last tick. As a result, the
+    /// effective resend interval is `resend_time` rounded up to the next multiple of `tick`,
+    /// and a request can wait up to one full tick beyond its nominal resend time before going
+    /// out again. Wraps NNG's [`NNG_OPT_REQ_RESENDTICK`] option.
+    ///
+    /// [`NNG_OPT_REQ_RESENDTICK`]: nng_sys::NNG_OPT_REQ_RESENDTICK
+    ///
+    /// Trade-off: a shorter tick tightens resend timing at the cost of more wakeups (and CPU);
+    /// a longer tick reduces overhead but coarsens resend timing. The default (one second) is
+    /// fine when `resend_time` is in the tens of seconds; lower it when `resend_time` itself is
+    /// sub-second, otherwise the tick dominates.
+    ///
+    /// Unlike [`set_resend_time`](Self::set_resend_time), this option has no per-context
+    /// equivalent and applies to every context on the socket.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tick` exceeds `i32::MAX` milliseconds.
+    pub fn set_resend_tick(&self, tick: Duration) {
+        crate::options::set_socket_ms(
+            self.id(),
+            nng_sys::NNG_OPT_REQ_RESENDTICK,
+            tick,
+            "resend tick",
+        );
+    }
+}
+
 impl<'socket> ContextfulSocket<'socket, Req0> {
+    /// Sets how long this context waits for a reply before re-sending the request.
+    ///
+    /// REQ0 retransmits an outstanding request whenever this duration elapses without a reply,
+    /// guarding against lost requests, dropped replies, or replier restarts. The context
+    /// inherits the socket value (default 60 seconds) at creation time; this method overrides
+    /// it for this context only and does not affect the socket default or other contexts.
+    /// Resend is checked at the socket-wide [tick interval](Socket::set_resend_tick), so the
+    /// actual retransmit can lag the nominal timeout by up to one tick. Wraps NNG's
+    /// [`NNG_OPT_REQ_RESENDTIME`] option.
+    ///
+    /// [`NNG_OPT_REQ_RESENDTIME`]: nng_sys::NNG_OPT_REQ_RESENDTIME
+    ///
+    /// Passing [`Duration::ZERO`] disables retransmission entirely: the request is sent once
+    /// and the receive future stays pending until either a reply arrives or the context (or
+    /// socket) is closed. NNG's `NNG_DURATION_INFINITE` sentinel has the same effect but is
+    /// negative and cannot be expressed as a [`Duration`] — use `Duration::ZERO` to get that
+    /// behaviour.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `timeout` exceeds `i32::MAX` milliseconds.
+    pub fn set_resend_time(&mut self, timeout: Duration) {
+        crate::options::set_ctx_ms(
+            self.context.id(),
+            nng_sys::NNG_OPT_REQ_RESENDTIME,
+            timeout,
+            "resend time",
+        );
+    }
+
     /// Sends a request and returns a future that will resolve to the reply.
     ///
     /// This method implements the client side of the Request/Reply pattern.
@@ -587,5 +681,59 @@ impl Responder<'_, '_> {
         } else {
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_resend_option_socket_smoke() {
+        let socket = Req0::socket().unwrap();
+        socket.set_resend_time(Duration::ZERO);
+        socket.set_resend_time(Duration::from_millis(1));
+        socket.set_resend_time(Duration::from_secs(60));
+        socket.set_resend_time(Duration::from_millis(i32::MAX as u64));
+
+        let socket = Req0::socket().unwrap();
+        socket.set_resend_tick(Duration::ZERO);
+        socket.set_resend_tick(Duration::from_millis(1));
+        socket.set_resend_tick(Duration::from_secs(1));
+        socket.set_resend_tick(Duration::from_millis(i32::MAX as u64));
+
+        let mut ctx = socket.context();
+        ctx.set_resend_time(Duration::ZERO);
+        ctx.set_resend_time(Duration::from_millis(50));
+        ctx.set_resend_time(Duration::from_secs(60));
+    }
+
+    #[test]
+    #[should_panic(expected = "resend time is too large")]
+    fn set_resend_time_socket_overflow_panics() {
+        let socket = Req0::socket().unwrap();
+        socket.set_resend_time(Duration::from_millis(i32::MAX as u64 + 1));
+    }
+
+    #[test]
+    #[should_panic(expected = "resend time is too large")]
+    fn set_resend_time_socket_duration_max_panics() {
+        let socket = Req0::socket().unwrap();
+        socket.set_resend_time(Duration::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "resend tick is too large")]
+    fn set_resend_tick_socket_overflow_panics() {
+        let socket = Req0::socket().unwrap();
+        socket.set_resend_tick(Duration::from_millis(i32::MAX as u64 + 1));
+    }
+
+    #[test]
+    #[should_panic(expected = "resend time is too large")]
+    fn set_resend_time_context_overflow_panics() {
+        let socket = Req0::socket().unwrap();
+        let mut ctx = socket.context();
+        ctx.set_resend_time(Duration::from_millis(i32::MAX as u64 + 1));
     }
 }

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -196,13 +196,13 @@ impl Socket<Req0> {
     /// # Panics
     ///
     /// Panics if `timeout` exceeds `i32::MAX` milliseconds.
-    pub fn set_resend_time(&self, timeout: Duration) {
+    pub fn set_resend_time(&self, timeout: Duration) -> io::Result<()> {
         crate::options::set_socket_ms(
             self.id(),
             nng_sys::NNG_OPT_REQ_RESENDTIME,
             timeout,
             "resend time",
-        );
+        )
     }
 
     /// Sets the granularity of the [resend time](Self::set_resend_time) timer.
@@ -226,13 +226,13 @@ impl Socket<Req0> {
     /// # Panics
     ///
     /// Panics if `tick` exceeds `i32::MAX` milliseconds.
-    pub fn set_resend_tick(&self, tick: Duration) {
+    pub fn set_resend_tick(&self, tick: Duration) -> io::Result<()> {
         crate::options::set_socket_ms(
             self.id(),
             nng_sys::NNG_OPT_REQ_RESENDTICK,
             tick,
             "resend tick",
-        );
+        )
     }
 }
 
@@ -258,13 +258,13 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
     /// # Panics
     ///
     /// Panics if `timeout` exceeds `i32::MAX` milliseconds.
-    pub fn set_resend_time(&mut self, timeout: Duration) {
+    pub fn set_resend_time(&mut self, timeout: Duration) -> io::Result<()> {
         crate::options::set_ctx_ms(
             self.context.id(),
             nng_sys::NNG_OPT_REQ_RESENDTIME,
             timeout,
             "resend time",
-        );
+        )
     }
 
     /// Sends a request and returns a future that will resolve to the reply.
@@ -691,42 +691,61 @@ mod tests {
     #[test]
     fn set_resend_option_socket_smoke() {
         let socket = Req0::socket().unwrap();
-        socket.set_resend_time(Duration::ZERO);
-        socket.set_resend_time(Duration::from_millis(1));
-        socket.set_resend_time(Duration::from_secs(60));
-        socket.set_resend_time(Duration::from_millis(i32::MAX as u64));
+        socket
+            .set_resend_time(Duration::ZERO)
+            .expect("can set resend time");
+        socket
+            .set_resend_time(Duration::from_millis(1))
+            .expect("can set resend time");
+        socket
+            .set_resend_time(Duration::from_secs(60))
+            .expect("can set resend time");
+        socket
+            .set_resend_time(Duration::from_millis(i32::MAX as u64))
+            .expect("can set resend time");
 
         let socket = Req0::socket().unwrap();
-        socket.set_resend_tick(Duration::ZERO);
-        socket.set_resend_tick(Duration::from_millis(1));
-        socket.set_resend_tick(Duration::from_secs(1));
-        socket.set_resend_tick(Duration::from_millis(i32::MAX as u64));
+        socket
+            .set_resend_tick(Duration::ZERO)
+            .expect("can set resend tick");
+        socket
+            .set_resend_tick(Duration::from_millis(1))
+            .expect("can set resend tick");
+        socket
+            .set_resend_tick(Duration::from_secs(1))
+            .expect("can set resend tick");
+        socket
+            .set_resend_tick(Duration::from_millis(i32::MAX as u64))
+            .expect("can set resend tick");
 
         let mut ctx = socket.context();
-        ctx.set_resend_time(Duration::ZERO);
-        ctx.set_resend_time(Duration::from_millis(50));
-        ctx.set_resend_time(Duration::from_secs(60));
+        ctx.set_resend_time(Duration::ZERO)
+            .expect("can set resend time");
+        ctx.set_resend_time(Duration::from_millis(50))
+            .expect("can set resend time");
+        ctx.set_resend_time(Duration::from_secs(60))
+            .expect("can set resend time");
     }
 
     #[test]
     #[should_panic(expected = "resend time is too large")]
     fn set_resend_time_socket_overflow_panics() {
         let socket = Req0::socket().unwrap();
-        socket.set_resend_time(Duration::from_millis(i32::MAX as u64 + 1));
+        let _ = socket.set_resend_time(Duration::from_millis(i32::MAX as u64 + 1));
     }
 
     #[test]
     #[should_panic(expected = "resend time is too large")]
     fn set_resend_time_socket_duration_max_panics() {
         let socket = Req0::socket().unwrap();
-        socket.set_resend_time(Duration::MAX);
+        let _ = socket.set_resend_time(Duration::MAX);
     }
 
     #[test]
     #[should_panic(expected = "resend tick is too large")]
     fn set_resend_tick_socket_overflow_panics() {
         let socket = Req0::socket().unwrap();
-        socket.set_resend_tick(Duration::from_millis(i32::MAX as u64 + 1));
+        let _ = socket.set_resend_tick(Duration::from_millis(i32::MAX as u64 + 1));
     }
 
     #[test]
@@ -734,6 +753,6 @@ mod tests {
     fn set_resend_time_context_overflow_panics() {
         let socket = Req0::socket().unwrap();
         let mut ctx = socket.context();
-        ctx.set_resend_time(Duration::from_millis(i32::MAX as u64 + 1));
+        let _ = ctx.set_resend_time(Duration::from_millis(i32::MAX as u64 + 1));
     }
 }

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -215,11 +215,6 @@ impl Socket<Req0> {
     ///
     /// [`NNG_OPT_REQ_RESENDTICK`]: nng_sys::NNG_OPT_REQ_RESENDTICK
     ///
-    /// Trade-off: a shorter tick tightens resend timing at the cost of more wakeups (and CPU);
-    /// a longer tick reduces overhead but coarsens resend timing. The default (one second) is
-    /// fine when `resend_time` is in the tens of seconds; lower it when `resend_time` itself is
-    /// sub-second, otherwise the tick dominates.
-    ///
     /// Unlike [`set_resend_time`](Self::set_resend_time), this option has no per-context
     /// equivalent and applies to every context on the socket.
     ///
@@ -241,11 +236,10 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
     ///
     /// REQ0 retransmits an outstanding request whenever this duration elapses without a reply,
     /// guarding against lost requests, dropped replies, or replier restarts. The context
-    /// inherits the socket value (default 60 seconds) at creation time; this method overrides
-    /// it for this context only and does not affect the socket default or other contexts.
-    /// Resend is checked at the socket-wide [tick interval](Socket::set_resend_tick), so the
-    /// actual retransmit can lag the nominal timeout by up to one tick. Wraps NNG's
-    /// [`NNG_OPT_REQ_RESENDTIME`] option.
+    /// inherits the socket value at creation time; this method overrides it for this context
+    /// only and does not affect the socket default or other contexts. Resend is checked at the
+    /// socket-wide [tick interval](Socket::set_resend_tick), so the actual retransmit can lag
+    /// the nominal timeout by up to one tick. Wraps NNG's [`NNG_OPT_REQ_RESENDTIME`] option.
     ///
     /// [`NNG_OPT_REQ_RESENDTIME`]: nng_sys::NNG_OPT_REQ_RESENDTIME
     ///

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -237,10 +237,10 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
     ///
     /// # Disabling the resend timer
     ///
-    /// Passing [`None`] (or, equivalently, [`Some(Duration::ZERO)`](Duration::ZERO)) disables
-    /// the periodic resend *timer*: the request is not re-sent on a fixed schedule while the
-    /// context waits for a reply. This maps to NNG's `NNG_DURATION_INFINITE` sentinel, which is
-    /// negative and therefore cannot be expressed as a [`Duration`] directly.
+    /// Passing [`None`] disables the periodic resend *timer*: the request is not re-sent on a
+    /// fixed schedule while the context waits for a reply. This maps to NNG's
+    /// `NNG_DURATION_INFINITE` sentinel, which is negative and therefore cannot be expressed as
+    /// a [`Duration`] directly.
     ///
     /// This does **not** make delivery "exactly once" and does not stop *all* retransmissions:
     /// NNG still automatically resends the request if the peer it was sent to disconnects, or
@@ -706,15 +706,7 @@ mod tests {
             read_socket_ms(&socket, nng_sys::NNG_OPT_REQ_RESENDTIME),
             nng_sys::NNG_DURATION_INFINITE,
         );
-        // `Some(Duration::ZERO)` is folded into the same "disable timer" behaviour.
-        socket
-            .set_resend_time(Some(Duration::ZERO))
-            .expect("can set resend time");
-        assert_eq!(
-            read_socket_ms(&socket, nng_sys::NNG_OPT_REQ_RESENDTIME),
-            nng_sys::NNG_DURATION_INFINITE,
-        );
-        for ms in [1, 60_000, i32::MAX] {
+        for ms in [0, 1, 60_000, i32::MAX] {
             socket
                 .set_resend_time(Some(Duration::from_millis(ms as u64)))
                 .expect("can set resend time");
@@ -735,13 +727,7 @@ mod tests {
             read_ctx_ms(&mut ctx, nng_sys::NNG_OPT_REQ_RESENDTIME),
             nng_sys::NNG_DURATION_INFINITE,
         );
-        ctx.set_resend_time(Some(Duration::ZERO))
-            .expect("can set resend time");
-        assert_eq!(
-            read_ctx_ms(&mut ctx, nng_sys::NNG_OPT_REQ_RESENDTIME),
-            nng_sys::NNG_DURATION_INFINITE,
-        );
-        for ms in [50, 60_000] {
+        for ms in [0, 50, 60_000] {
             ctx.set_resend_time(Some(Duration::from_millis(ms as u64)))
                 .expect("can set resend time");
             assert_eq!(read_ctx_ms(&mut ctx, nng_sys::NNG_OPT_REQ_RESENDTIME), ms);

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -185,7 +185,7 @@ impl Socket<Req0> {
     /// Panics if `timeout` is `Some(duration)` and `duration` exceeds `i32::MAX` milliseconds.
     pub fn set_resend_time(&self, timeout: Option<Duration>) -> io::Result<()> {
         crate::options::set_socket_ms_opt(
-            self.id(),
+            self,
             crate::options::opt(nng_sys::NNG_OPT_REQ_RESENDTIME),
             timeout,
             "resend time",
@@ -215,7 +215,7 @@ impl Socket<Req0> {
     /// Panics if `tick` exceeds `i32::MAX` milliseconds.
     pub fn set_resend_tick(&self, tick: Duration) -> io::Result<()> {
         crate::options::set_socket_ms(
-            self.id(),
+            self,
             crate::options::opt(nng_sys::NNG_OPT_REQ_RESENDTICK),
             tick,
             "resend tick",
@@ -252,7 +252,7 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
     /// Panics if `timeout` is `Some(duration)` and `duration` exceeds `i32::MAX` milliseconds.
     pub fn set_resend_time(&mut self, timeout: Option<Duration>) -> io::Result<()> {
         crate::options::set_ctx_ms_opt(
-            self.context.id(),
+            &mut self.context,
             crate::options::opt(nng_sys::NNG_OPT_REQ_RESENDTIME),
             timeout,
             "resend time",
@@ -716,8 +716,7 @@ mod tests {
             .expect("can set resend tick");
 
         let mut ctx = socket.context();
-        ctx.set_resend_time(None)
-            .expect("can disable resend timer");
+        ctx.set_resend_time(None).expect("can disable resend timer");
         ctx.set_resend_time(Some(Duration::ZERO))
             .expect("can set resend time");
         ctx.set_resend_time(Some(Duration::from_millis(50)))

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -218,6 +218,11 @@ impl Socket<Req0> {
     /// Unlike [`set_resend_time`](Self::set_resend_time), this option has no per-context
     /// equivalent and applies to every context on the socket.
     ///
+    /// A shorter tick gives more timely retransmits, but each tick re-scans every outstanding
+    /// request, so very short values can add significant overhead on sockets with many contexts.
+    /// The clock is idle whenever no request is awaiting a reply, so the cost only appears under
+    /// load.
+    ///
     /// # Panics
     ///
     /// Panics if `tick` exceeds `i32::MAX` milliseconds.

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -682,47 +682,70 @@ mod tests {
 
     #[test]
     fn set_resend_option_socket_smoke() {
+        let read_socket_ms = |socket: &Socket<Req0>, opt: &[u8]| -> i32 {
+            let mut ms: i32 = 0;
+            let rc =
+                unsafe { nng_sys::nng_socket_get_ms(socket.id(), opt.as_ptr().cast(), &mut ms) };
+            assert_eq!(rc, 0, "nng_socket_get_ms failed: {rc}");
+            ms
+        };
+        let read_ctx_ms = |ctx: &mut ContextfulSocket<Req0>, opt: &[u8]| -> i32 {
+            let mut ms: i32 = 0;
+            let rc =
+                unsafe { nng_sys::nng_ctx_get_ms(ctx.context.id(), opt.as_ptr().cast(), &mut ms) };
+            assert_eq!(rc, 0, "nng_ctx_get_ms failed: {rc}");
+            ms
+        };
+
         let socket = Req0::socket().unwrap();
         // `None` disables the resend timer (maps to NNG_DURATION_INFINITE).
         socket
             .set_resend_time(None)
             .expect("can disable resend timer");
+        assert_eq!(
+            read_socket_ms(&socket, nng_sys::NNG_OPT_REQ_RESENDTIME),
+            nng_sys::NNG_DURATION_INFINITE,
+        );
         // `Some(Duration::ZERO)` is folded into the same "disable timer" behaviour.
         socket
             .set_resend_time(Some(Duration::ZERO))
             .expect("can set resend time");
-        socket
-            .set_resend_time(Some(Duration::from_millis(1)))
-            .expect("can set resend time");
-        socket
-            .set_resend_time(Some(Duration::from_secs(60)))
-            .expect("can set resend time");
-        socket
-            .set_resend_time(Some(Duration::from_millis(i32::MAX as u64)))
-            .expect("can set resend time");
+        assert_eq!(
+            read_socket_ms(&socket, nng_sys::NNG_OPT_REQ_RESENDTIME),
+            nng_sys::NNG_DURATION_INFINITE,
+        );
+        for ms in [1, 60_000, i32::MAX] {
+            socket
+                .set_resend_time(Some(Duration::from_millis(ms as u64)))
+                .expect("can set resend time");
+            assert_eq!(read_socket_ms(&socket, nng_sys::NNG_OPT_REQ_RESENDTIME), ms);
+        }
 
         let socket = Req0::socket().unwrap();
-        socket
-            .set_resend_tick(Duration::ZERO)
-            .expect("can set resend tick");
-        socket
-            .set_resend_tick(Duration::from_millis(1))
-            .expect("can set resend tick");
-        socket
-            .set_resend_tick(Duration::from_secs(1))
-            .expect("can set resend tick");
-        socket
-            .set_resend_tick(Duration::from_millis(i32::MAX as u64))
-            .expect("can set resend tick");
+        for ms in [0, 1, 1_000, i32::MAX] {
+            socket
+                .set_resend_tick(Duration::from_millis(ms as u64))
+                .expect("can set resend tick");
+            assert_eq!(read_socket_ms(&socket, nng_sys::NNG_OPT_REQ_RESENDTICK), ms);
+        }
 
         let mut ctx = socket.context();
         ctx.set_resend_time(None).expect("can disable resend timer");
+        assert_eq!(
+            read_ctx_ms(&mut ctx, nng_sys::NNG_OPT_REQ_RESENDTIME),
+            nng_sys::NNG_DURATION_INFINITE,
+        );
         ctx.set_resend_time(Some(Duration::ZERO))
             .expect("can set resend time");
-        ctx.set_resend_time(Some(Duration::from_millis(50)))
-            .expect("can set resend time");
-        ctx.set_resend_time(Some(Duration::from_secs(60)))
-            .expect("can set resend time");
+        assert_eq!(
+            read_ctx_ms(&mut ctx, nng_sys::NNG_OPT_REQ_RESENDTIME),
+            nng_sys::NNG_DURATION_INFINITE,
+        );
+        for ms in [50, 60_000] {
+            ctx.set_resend_time(Some(Duration::from_millis(ms as u64)))
+                .expect("can set resend time");
+            assert_eq!(read_ctx_ms(&mut ctx, nng_sys::NNG_OPT_REQ_RESENDTIME), ms);
+        }
     }
 
     #[test]

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -173,25 +173,11 @@ impl Req0 {
 }
 
 impl Socket<Req0> {
-    /// Sets how long the socket waits for a reply before re-sending the request.
+    /// Sets the socket-wide default resend timeout inherited by future contexts.
     ///
-    /// REQ0 retransmits an outstanding request whenever this duration elapses without a reply,
-    /// guarding against lost requests, dropped replies, or replier restarts. The default is 60
-    /// seconds; resend is checked at the [tick interval](Self::set_resend_tick), so the actual
-    /// retransmit can lag the nominal timeout by up to one tick. Wraps NNG's
-    /// [`NNG_OPT_REQ_RESENDTIME`] option.
-    ///
-    /// [`NNG_OPT_REQ_RESENDTIME`]: nng_sys::NNG_OPT_REQ_RESENDTIME
-    ///
-    /// Passing [`Duration::ZERO`] disables retransmission entirely: the request is sent once
-    /// and the receive future stays pending until either a reply arrives or the socket is
-    /// closed. NNG's `NNG_DURATION_INFINITE` sentinel has the same effect but is negative and
-    /// cannot be expressed as a [`Duration`] — use `Duration::ZERO` to get that behaviour.
-    ///
-    /// This is the socket-wide value. Each context snapshots it at creation time, so changing
-    /// it here only affects contexts created afterwards; pre-existing contexts keep whatever
-    /// value they were created with (and can override per-context via
-    /// [`ContextfulSocket::set_resend_time`]).
+    /// See [`ContextfulSocket::set_resend_time`] for the full semantics. This setter only
+    /// changes the default snapshotted by contexts at creation time; pre-existing contexts
+    /// keep whatever value they were created with.
     ///
     /// # Panics
     ///

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -175,15 +175,16 @@ impl Req0 {
 impl Socket<Req0> {
     /// Sets the socket-wide default resend timeout inherited by future contexts.
     ///
-    /// See [`ContextfulSocket::set_resend_time`] for the full semantics. This setter only
-    /// changes the default snapshotted by contexts at creation time; pre-existing contexts
-    /// keep whatever value they were created with.
+    /// See [`ContextfulSocket::set_resend_time`] for the full semantics, including how
+    /// [`None`] disables the resend *timer*. This setter only changes the default snapshotted
+    /// by contexts at creation time; pre-existing contexts keep whatever value they were
+    /// created with.
     ///
     /// # Panics
     ///
-    /// Panics if `timeout` exceeds `i32::MAX` milliseconds.
-    pub fn set_resend_time(&self, timeout: Duration) -> io::Result<()> {
-        crate::options::set_socket_ms(
+    /// Panics if `timeout` is `Some(duration)` and `duration` exceeds `i32::MAX` milliseconds.
+    pub fn set_resend_time(&self, timeout: Option<Duration>) -> io::Result<()> {
+        crate::options::set_socket_ms_opt(
             self.id(),
             crate::options::opt(nng_sys::NNG_OPT_REQ_RESENDTIME),
             timeout,
@@ -223,7 +224,7 @@ impl Socket<Req0> {
 }
 
 impl<'socket> ContextfulSocket<'socket, Req0> {
-    /// Sets how long this context waits for a reply before re-sending the request.
+    /// Sets how long this context waits for a reply before re-sending the request on a timer.
     ///
     /// REQ0 retransmits an outstanding request whenever this duration elapses without a reply,
     /// guarding against lost requests, dropped replies, or replier restarts. The context
@@ -234,17 +235,23 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
     ///
     /// [`NNG_OPT_REQ_RESENDTIME`]: nng_sys::NNG_OPT_REQ_RESENDTIME
     ///
-    /// Passing [`Duration::ZERO`] disables retransmission entirely: the request is sent once
-    /// and the receive future stays pending until either a reply arrives or the context (or
-    /// socket) is closed. NNG's `NNG_DURATION_INFINITE` sentinel has the same effect but is
-    /// negative and cannot be expressed as a [`Duration`] — use `Duration::ZERO` to get that
-    /// behaviour.
+    /// # Disabling the resend timer
+    ///
+    /// Passing [`None`] (or, equivalently, [`Some(Duration::ZERO)`](Duration::ZERO)) disables
+    /// the periodic resend *timer*: the request is not re-sent on a fixed schedule while the
+    /// context waits for a reply. This maps to NNG's `NNG_DURATION_INFINITE` sentinel, which is
+    /// negative and therefore cannot be expressed as a [`Duration`] directly.
+    ///
+    /// This does **not** make delivery "exactly once" and does not stop *all* retransmissions:
+    /// NNG still automatically resends the request if the peer it was sent to disconnects, or
+    /// if a new peer becomes available while the requester is waiting for one. Requests should
+    /// therefore remain idempotent even with the timer disabled.
     ///
     /// # Panics
     ///
-    /// Panics if `timeout` exceeds `i32::MAX` milliseconds.
-    pub fn set_resend_time(&mut self, timeout: Duration) -> io::Result<()> {
-        crate::options::set_ctx_ms(
+    /// Panics if `timeout` is `Some(duration)` and `duration` exceeds `i32::MAX` milliseconds.
+    pub fn set_resend_time(&mut self, timeout: Option<Duration>) -> io::Result<()> {
+        crate::options::set_ctx_ms_opt(
             self.context.id(),
             crate::options::opt(nng_sys::NNG_OPT_REQ_RESENDTIME),
             timeout,
@@ -676,17 +683,22 @@ mod tests {
     #[test]
     fn set_resend_option_socket_smoke() {
         let socket = Req0::socket().unwrap();
+        // `None` disables the resend timer (maps to NNG_DURATION_INFINITE).
         socket
-            .set_resend_time(Duration::ZERO)
+            .set_resend_time(None)
+            .expect("can disable resend timer");
+        // `Some(Duration::ZERO)` is folded into the same "disable timer" behaviour.
+        socket
+            .set_resend_time(Some(Duration::ZERO))
             .expect("can set resend time");
         socket
-            .set_resend_time(Duration::from_millis(1))
+            .set_resend_time(Some(Duration::from_millis(1)))
             .expect("can set resend time");
         socket
-            .set_resend_time(Duration::from_secs(60))
+            .set_resend_time(Some(Duration::from_secs(60)))
             .expect("can set resend time");
         socket
-            .set_resend_time(Duration::from_millis(i32::MAX as u64))
+            .set_resend_time(Some(Duration::from_millis(i32::MAX as u64)))
             .expect("can set resend time");
 
         let socket = Req0::socket().unwrap();
@@ -704,11 +716,13 @@ mod tests {
             .expect("can set resend tick");
 
         let mut ctx = socket.context();
-        ctx.set_resend_time(Duration::ZERO)
+        ctx.set_resend_time(None)
+            .expect("can disable resend timer");
+        ctx.set_resend_time(Some(Duration::ZERO))
             .expect("can set resend time");
-        ctx.set_resend_time(Duration::from_millis(50))
+        ctx.set_resend_time(Some(Duration::from_millis(50)))
             .expect("can set resend time");
-        ctx.set_resend_time(Duration::from_secs(60))
+        ctx.set_resend_time(Some(Duration::from_secs(60)))
             .expect("can set resend time");
     }
 
@@ -716,14 +730,14 @@ mod tests {
     #[should_panic(expected = "resend time is too large")]
     fn set_resend_time_socket_overflow_panics() {
         let socket = Req0::socket().unwrap();
-        let _ = socket.set_resend_time(Duration::from_millis(i32::MAX as u64 + 1));
+        let _ = socket.set_resend_time(Some(Duration::from_millis(i32::MAX as u64 + 1)));
     }
 
     #[test]
     #[should_panic(expected = "resend time is too large")]
     fn set_resend_time_socket_duration_max_panics() {
         let socket = Req0::socket().unwrap();
-        let _ = socket.set_resend_time(Duration::MAX);
+        let _ = socket.set_resend_time(Some(Duration::MAX));
     }
 
     #[test]
@@ -738,6 +752,6 @@ mod tests {
     fn set_resend_time_context_overflow_panics() {
         let socket = Req0::socket().unwrap();
         let mut ctx = socket.context();
-        let _ = ctx.set_resend_time(Duration::from_millis(i32::MAX as u64 + 1));
+        let _ = ctx.set_resend_time(Some(Duration::from_millis(i32::MAX as u64 + 1)));
     }
 }

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -185,7 +185,7 @@ impl Socket<Req0> {
     pub fn set_resend_time(&self, timeout: Duration) -> io::Result<()> {
         crate::options::set_socket_ms(
             self.id(),
-            nng_sys::NNG_OPT_REQ_RESENDTIME,
+            crate::options::opt(nng_sys::NNG_OPT_REQ_RESENDTIME),
             timeout,
             "resend time",
         )
@@ -215,7 +215,7 @@ impl Socket<Req0> {
     pub fn set_resend_tick(&self, tick: Duration) -> io::Result<()> {
         crate::options::set_socket_ms(
             self.id(),
-            nng_sys::NNG_OPT_REQ_RESENDTICK,
+            crate::options::opt(nng_sys::NNG_OPT_REQ_RESENDTICK),
             tick,
             "resend tick",
         )
@@ -246,7 +246,7 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
     pub fn set_resend_time(&mut self, timeout: Duration) -> io::Result<()> {
         crate::options::set_ctx_ms(
             self.context.id(),
-            nng_sys::NNG_OPT_REQ_RESENDTIME,
+            crate::options::opt(nng_sys::NNG_OPT_REQ_RESENDTIME),
             timeout,
             "resend time",
         )


### PR DESCRIPTION
Add `Socket<Req0>::set_resend_time/set_resend_tick` and `ContextfulSocket<Req0>::set_resend_time`, wrapping the `NNG_OPT_REQ_RESENDTIME` and `NNG_OPT_REQ_RESENDTICK` options.

Introduce a crate-internal options helper module that centralizes the duration bounds check, the unsafe FFI call, and exhaustive errno handling for `nng_socket_set_ms` / `nng_ctx_set_ms`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REQ0 sockets can configure retransmission: set socket-level resend timeout and tick interval; contexts can override the resend timeout.

* **Behavior**
  * Duration inputs validated; excessively large values now panic or return errors rather than silently truncating. Optional durations map None/zero to the “disabled/infinite” sentinel.

* **Tests**
  * Added tests for normal settings, sentinel mapping, and overflow panic cases.

* **Chores**
  * Internal duration/option helpers consolidated into a shared module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->