### PR TITLE
ci: unify workspace on NNG v2 and tidy install steps

### DIFF
--- a/.github/workflows/build-configurations.yml
+++ b/.github/workflows/build-configurations.yml
@@ -20,12 +20,6 @@ jobs:
             features: # no-default-features, so this won't vendor, and system implies bindgen
             # clang and cmake for installing NNG, clang-dev for bindgen
             apt: clang cmake libclang-dev
-            # until nng v2 is available via apt, we need to manually install nng
-            # for the checks that expect nng to be installed in the system
-            # 
-            # TODO(flxo): remove the manual installation of nng and replace with
-            # a `apt install libnng2 libnng-dev` or similar, once the apt
-            # packages are available. Same applies for `brew` and others.
             install_nng: true
             env: {}
           - name: vendored + bindgen
@@ -79,10 +73,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           submodules: true
-      # the nng crate is not yet upgraded to nng v2. install nng v1.x (libnng1 and libnng-dev)
       - name: Install dependencies
         run: |
-          sudo apt-get install -y libnng1 libnng-dev
+          sudo apt-get install -y clang cmake
+      - name: Build and install NNG
+        run: .github/scripts/install-nng.sh
       - name: Install stable
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # branch=master
         with:
@@ -91,6 +86,8 @@ jobs:
         run: cargo test -p nng --locked --all-targets --no-default-features
         env:
           NNG_NO_VENDOR: "1"
+          CFLAGS: -I/usr/local/include
+          RUSTFLAGS: -L native=/usr/local/lib
   linux-force-no-vendor:
     name: nng on linux / NNG_NO_VENDOR
     runs-on: ubuntu-latest

--- a/.github/workflows/build-configurations.yml
+++ b/.github/workflows/build-configurations.yml
@@ -20,6 +20,12 @@ jobs:
             features: # no-default-features, so this won't vendor, and system implies bindgen
             # clang and cmake for installing NNG, clang-dev for bindgen
             apt: clang cmake libclang-dev
+            # until nng v2 is available via apt, we need to manually install nng
+            # for the checks that expect nng to be installed in the system.
+            #
+            # TODO(flxo): remove the manual installation of nng and replace with
+            # a `apt install libnng2 libnng-dev` or similar, once the apt
+            # packages are available. Same applies for `brew` and others.
             install_nng: true
             env: {}
           - name: vendored + bindgen
@@ -74,6 +80,8 @@ jobs:
         with:
           submodules: true
       - name: Install dependencies
+        # TODO(flxo): replace the manual installation of nng from source once nng v2 is available
+        # via apt.
         run: |
           sudo apt-get install -y clang cmake
       - name: Build and install NNG

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -120,35 +120,13 @@ jobs:
       # since we're trying every combination here, we need to ensure we have
       # all the various tools installed already.
       - name: install tools
-        run: sudo apt-get install -y libclang-dev clang cmake ninja-build libmbedtls-dev libnng1 libnng-dev
-      # Run cargo hack per-package because nng-sys v0.4 targets NNG v2, while
-      # nng and anng still depend on nng-sys v0.3 (NNG v1). Running feature-powerset
-      # on the entire workspace fails since these require incompatible NNG versions.
-      # The effect of the failure (when running `hack` on the workspace) is here:
-      # https://github.com/nanomsg/nng-rs/actions/runs/20988550343/job/60328143824
-      #
-      # TODO: Remove this workaround once nng is migrated to nng-sys v0.4/NNG v2
-      # and revert to:
-      # - name: cargo hack
-      #   run: cargo hack --feature-powerset check --skip source-update-bindings
-      #
-      # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
-      # --feature-powerset runs for every combination of features
-      - name: cargo hack nng
-        run: cargo hack -p nng --feature-powerset check
-      - name: remove NNG v1
-        run: sudo apt-get remove -y libnng1 libnng-dev
+        run: sudo apt-get install -y libclang-dev clang cmake ninja-build libmbedtls-dev
       - name: build and install NNG v2 for nng-sys
         run: .github/scripts/install-nng.sh
-      - name: cargo hack anng
-        run: cargo hack -p anng --feature-powerset check
-        env:
-          # add /usr/local/include to the C compiler search path for NNG headers
-          CFLAGS: -I/usr/local/include
-          # add /usr/local/lib to the linker search path for NNG libraries
-          RUSTFLAGS: -L native=/usr/local/lib
-      - name: cargo hack nng-sys
-        run: cargo hack -p nng-sys --feature-powerset check --skip source-update-bindings
+      # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
+      # --feature-powerset runs for every combination of features
+      - name: cargo hack
+        run: cargo hack --feature-powerset check --skip source-update-bindings
         env:
           # add /usr/local/include to the C compiler search path for NNG headers
           CFLAGS: -I/usr/local/include

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -120,6 +120,8 @@ jobs:
       # since we're trying every combination here, we need to ensure we have
       # all the various tools installed already.
       - name: install tools
+        # TODO(flxo): replace the nng v2 installation from source once it's available
+        # via apt.
         run: sudo apt-get install -y libclang-dev clang cmake ninja-build libmbedtls-dev
       - name: build and install NNG v2 for nng-sys
         run: .github/scripts/install-nng.sh


### PR DESCRIPTION
With `nng` now depending on `nng-sys 0.4` (NNG v2) alongside `anng`, the per-package `cargo hack` workaround in `check.yml` is no longer needed; run feature-powerset across the whole workspace against a single NNG v2 install built from the helper script.

In `build-configurations.yml`:

- Restore the `if: matrix.install_nng` guard on the Linux/macOS NNG install step so vendored matrix entries don't waste CI building NNG they never link against.
- Update the `linux-nng` job to install NNG v2 via the helper script (with `CFLAGS`/`RUSTFLAGS` pointing at `/usr/local`) instead of the apt `libnng1`/`libnng-dev` packages, which are NNG v1 and no longer match the `nng` crate's `nng-sys` dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI build workflow now installs NNG via a shared installer, reduces package installs, and sets include/lib paths for native builds.
  * Continuous-check workflow consolidated per-crate checks into a single workspace-level feature-powerset run, with unified environment flags for native bindings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng-rs/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->