### PR TITLE
anng: handle ECLOSED/ESTOPPED/ECONNABORTED/ETIMEDOUT from nng_dialer_start and ECLOSED in add_listener_to_socket

### DIFF
--- a/anng/src/lib.rs
+++ b/anng/src/lib.rs
@@ -445,7 +445,7 @@ impl<Protocol> Socket<Protocol> {
         url: impl AsRef<CStr>,
         options: &pipes::PipeOptions,
     ) -> io::Result<pipes::Dialer<'socket, Protocol>> {
-        let dialer = crate::protocols::add_dialer_to_socket(self.socket, url.as_ref(), |_dialer| {
+        let dialer = crate::protocols::add_dialer_to_socket(self, url.as_ref(), |_dialer| {
             let pipes::PipeOptions {} = options;
             Ok(())
         })

--- a/anng/src/lib.rs
+++ b/anng/src/lib.rs
@@ -497,7 +497,7 @@ impl<Protocol> Socket<Protocol> {
         options: &pipes::PipeOptions,
     ) -> io::Result<pipes::Listener<'socket, Protocol>> {
         let listener =
-            crate::protocols::add_listener_to_socket(self.socket, url.as_ref(), |_listener| {
+            crate::protocols::add_listener_to_socket(self, url.as_ref(), |_listener| {
                 let pipes::PipeOptions {} = options;
                 Ok(())
             })

--- a/anng/src/lib.rs
+++ b/anng/src/lib.rs
@@ -497,12 +497,11 @@ impl<Protocol> Socket<Protocol> {
         url: impl AsRef<CStr>,
         options: &pipes::PipeOptions,
     ) -> io::Result<pipes::Listener<'socket, Protocol>> {
-        let listener =
-            crate::protocols::add_listener_to_socket(self, url.as_ref(), |_listener| {
-                let pipes::PipeOptions {} = options;
-                Ok(())
-            })
-            .await?;
+        let listener = crate::protocols::add_listener_to_socket(self, url.as_ref(), |_listener| {
+            let pipes::PipeOptions {} = options;
+            Ok(())
+        })
+        .await?;
         Ok(pipes::Listener {
             socket: self,
             listener,

--- a/anng/src/pipes.rs
+++ b/anng/src/pipes.rs
@@ -322,7 +322,7 @@ impl<Protocol> Socket<Protocol> {
         // the Display impl of SocketAddr prints 1.2.3.4:5 or [ab:cd:ef]:5,
         // which matches what NNG expects.
         let url = CString::new(format!("tcp://{addr}")).expect("no null bytes in addr");
-        let listener = crate::protocols::add_listener_to_socket(self.socket, &url, |listener| {
+        let listener = crate::protocols::add_listener_to_socket(self, &url, |listener| {
             let &TcpOptions {
                 no_delay,
                 keep_alive,

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -238,20 +238,31 @@ pub(crate) async fn add_dialer_to_socket(
         // the dialing.
         match u32::try_from(errno).expect("errno is never negative") {
             0 => Ok(()),
-            err if err == ErrorCode::ECLOSED as u32 => {
-                unreachable!("the socket is still valid");
+            err if err == ErrorCode::ECANCELED as u32 => {
+                // `nng_dialer_start` runs inside `spawn_blocking`. dropping the dial future
+                // (e.g. via `tokio::select!`) detaches this worker and releases the
+                // `&'socket self` borrow, letting the caller drop its `Socket`. nng then
+                // cancels the in-flight I/O on the socket and surfaces `ECANCELED`. the
+                // caller is gone and does not care about the result.
+                tracing::debug!("dial future dropped while (now-cancelled) dial still running");
+                Err(io::Error::from(AioError::Cancelled))
+            }
+            err if err == ErrorCode::ECLOSED as u32 || err == ErrorCode::ESTOPPED as u32 => {
+                // the socket (`ECLOSED`) or the whole nng runtime (`ESTOPPED`, e.g. via
+                // `nng_fini`) was torn down underneath the dial. this most commonly happens
+                // when the dial future was dropped and the caller dropped its `Socket`, in
+                // which case the detached worker's return value is discarded. but it can also
+                // happen while a caller is *still* awaiting (another path closed the socket,
+                // or the runtime was deinitialised), and that caller must be told the real
+                // failure rather than a spurious `Cancelled`. surface the genuine error;
+                // tokio discards it for the dropped-future case.
+                tracing::debug!(errno = err, "socket or runtime torn down during dial");
+                Err(io::Error::from(AioError::Operation(
+                    ErrorKind::from_nz_u32(NonZeroU32::new(err).expect("0 is checked above")),
+                )))
             }
             err if err == ErrorCode::ESTATE as u32 => {
                 unreachable!("the dialer has not been started");
-            }
-            err if err == ErrorCode::ECANCELED as u32 => {
-                // this can happen if the dial future is dropped (such as if the future is
-                // cancelled), and that _also_ drops the referenced socket. if this occurrs, any
-                // I/O operation on the socket is cancelled by nng, and thus we get that error.
-                // we don't need to _do_ anything with it though, since we _know_ the caller has
-                // gone away (and thus doesn't care about our return value).
-                tracing::warn!("socket dropped while (now-cancelled) dial future still running");
-                Err(io::Error::from(AioError::Cancelled))
             }
             err if err == ErrorCode::EAGAIN as u32 => {
                 // this is returned from `getaddrinfo` if there's a temporary failure in name
@@ -272,11 +283,13 @@ pub(crate) async fn add_dialer_to_socket(
                 panic!("OOM");
             }
             err if err == ErrorCode::EADDRINVAL as u32
+                || err == ErrorCode::ECONNABORTED as u32
                 || err == ErrorCode::ECONNREFUSED as u32
                 || err == ErrorCode::ECONNRESET as u32
                 || err == ErrorCode::EINVAL as u32
                 || err == ErrorCode::EPEERAUTH as u32
                 || err == ErrorCode::EPROTO as u32
+                || err == ErrorCode::ETIMEDOUT as u32
                 || err == ErrorCode::EUNREACHABLE as u32 =>
             {
                 Err(io::Error::from(AioError::Operation(

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -238,15 +238,6 @@ pub(crate) async fn add_dialer_to_socket(
         // the dialing.
         match u32::try_from(errno).expect("errno is never negative") {
             0 => Ok(()),
-            err if err == ErrorCode::ECANCELED as u32 => {
-                // `nng_dialer_start` runs inside `spawn_blocking`. dropping the dial future
-                // (e.g. via `tokio::select!`) detaches this worker and releases the
-                // `&'socket self` borrow, letting the caller drop its `Socket`. nng then
-                // cancels the in-flight I/O on the socket and surfaces `ECANCELED`. the
-                // caller is gone and does not care about the result.
-                tracing::debug!("dial future dropped while (now-cancelled) dial still running");
-                Err(io::Error::from(AioError::Cancelled))
-            }
             err if err == ErrorCode::ECLOSED as u32 || err == ErrorCode::ESTOPPED as u32 => {
                 // the socket (`ECLOSED`) or the whole nng runtime (`ESTOPPED`, e.g. via
                 // `nng_fini`) was torn down underneath the dial. this most commonly happens
@@ -263,6 +254,15 @@ pub(crate) async fn add_dialer_to_socket(
             }
             err if err == ErrorCode::ESTATE as u32 => {
                 unreachable!("the dialer has not been started");
+            }
+            err if err == ErrorCode::ECANCELED as u32 => {
+                // this can happen if the dial future is dropped (such as if the future is
+                // cancelled), and that _also_ drops the referenced socket. if this occurrs, any
+                // I/O operation on the socket is cancelled by nng, and thus we get that error.
+                // we don't need to _do_ anything with it though, since we _know_ the caller has
+                // gone away (and thus doesn't care about our return value).
+                tracing::warn!("socket dropped while (now-cancelled) dial future still running");
+                Err(io::Error::from(AioError::Cancelled))
             }
             err if err == ErrorCode::EAGAIN as u32 => {
                 // this is returned from `getaddrinfo` if there's a temporary failure in name

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -282,6 +282,12 @@ pub(crate) async fn add_dialer_to_socket(
             err if err == ErrorCode::ENOMEM as u32 => {
                 panic!("OOM");
             }
+            err if err == ErrorCode::ETIMEDOUT as u32 => {
+                // route through the outer TimedOut variant so the From<AioError> for io::Error
+                // impl maps this to io::ErrorKind::TimedOut (the NngError(ETIMEDOUT) arm is
+                // marked unreachable!).
+                Err(io::Error::from(AioError::TimedOut))
+            }
             err if err == ErrorCode::EADDRINVAL as u32
                 || err == ErrorCode::ECONNABORTED as u32
                 || err == ErrorCode::ECONNREFUSED as u32
@@ -289,7 +295,6 @@ pub(crate) async fn add_dialer_to_socket(
                 || err == ErrorCode::EINVAL as u32
                 || err == ErrorCode::EPEERAUTH as u32
                 || err == ErrorCode::EPROTO as u32
-                || err == ErrorCode::ETIMEDOUT as u32
                 || err == ErrorCode::EUNREACHABLE as u32 =>
             {
                 Err(io::Error::from(AioError::Operation(

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -238,19 +238,28 @@ pub(crate) async fn add_dialer_to_socket(
         // the dialing.
         match u32::try_from(errno).expect("errno is never negative") {
             0 => Ok(()),
-            err if err == ErrorCode::ECLOSED as u32 || err == ErrorCode::ESTOPPED as u32 => {
-                // the socket (`ECLOSED`) or the whole nng runtime (`ESTOPPED`, e.g. via
-                // `nng_fini`) was torn down underneath the dial. this most commonly happens
-                // when the dial future was dropped and the caller dropped its `Socket`, in
-                // which case the detached worker's return value is discarded. but it can also
-                // happen while a caller is *still* awaiting (another path closed the socket,
-                // or the runtime was deinitialised), and that caller must be told the real
-                // failure rather than a spurious `Cancelled`. surface the genuine error;
-                // tokio discards it for the dropped-future case.
-                tracing::debug!(errno = err, "socket or runtime torn down during dial");
-                Err(io::Error::from(AioError::Operation(
-                    ErrorKind::from_nz_u32(NonZeroU32::new(err).expect("0 is checked above")),
-                )))
+            err if err == ErrorCode::ECLOSED as u32 => {
+                // the socket was closed underneath the dial. while the dial future is still
+                // awaiting it holds `&'socket self`, and `Socket::drop` needs `&mut self`,
+                // so the borrow checker prevents the socket from being closed out from under
+                // us. the only way to reach `ECLOSED` here is therefore: the dial future was
+                // dropped, the worker detached, and the caller subsequently dropped the
+                // `Socket`. in that case nobody is listening for our return value, so map
+                // this like `ECANCELED`.
+                tracing::debug!("socket closed after dial future was dropped");
+                Err(io::Error::from(AioError::Cancelled))
+            }
+            err if err == ErrorCode::ESTOPPED as u32 => {
+                // the whole nng runtime was torn down (e.g. via `nng_fini` /
+                // `deinit_nng`). that API is `unsafe` and its contract requires all sockets
+                // to be closed first, so a correct caller won't hit this mid-await. but a
+                // misuse — or a racy shutdown sequence — can tear down the runtime while a
+                // dial is still in flight. surface the real error so a caller that is still
+                // awaiting learns the truth; for the dropped-future case tokio discards it.
+                tracing::warn!("nng runtime torn down during dial");
+                Err(io::Error::from(AioError::Operation(ErrorKind::NngError(
+                    ErrorCode::ESTOPPED,
+                ))))
             }
             err if err == ErrorCode::ESTATE as u32 => {
                 unreachable!("the dialer has not been started");

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -256,7 +256,7 @@ pub(crate) async fn add_dialer_to_socket(
                 // dropped, the worker detached, and the caller subsequently dropped the
                 // `Socket`. in that case nobody is listening for our return value, so map
                 // this like `ECANCELED`.
-                tracing::debug!("socket closed after dial future was dropped");
+                tracing::warn!("socket closed after dial future was dropped");
                 Err(io::Error::from(AioError::Cancelled))
             }
             err if err == ErrorCode::ESTOPPED as u32 => {

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -156,6 +156,16 @@ pub(crate) async fn add_listener_to_socket(
         err if err == ErrorCode::ESTATE as u32 => {
             unreachable!("the listener is not already started");
         }
+        err if err == ErrorCode::ESTOPPED as u32 => {
+            // the whole nng runtime was torn down (e.g. via `nng_fini` / `deinit_nng`)
+            // while we were starting the listener. that API is `unsafe` and its contract
+            // requires all sockets to be closed first, so a correct caller won't hit this,
+            // but a misuse — or a racy shutdown sequence — can surface it here.
+            tracing::warn!("nng runtime torn down during listener start");
+            return Err(io::Error::from(AioError::Operation(ErrorKind::NngError(
+                ErrorCode::ESTOPPED,
+            ))));
+        }
         err if err == ErrorCode::EADDRINUSE as u32 || err == ErrorCode::EPERM as u32 => {
             return Err(io::Error::from(AioError::Operation(
                 ErrorKind::from_nz_u32(NonZeroU32::new(err).expect("0 is checked above")),

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -190,10 +190,6 @@ pub(crate) async fn add_listener_to_socket(
 }
 
 /// Adds a dialer to an existing socket.
-///
-/// # Safety
-///
-/// The socket must be a valid, open NNG socket.
 pub(crate) async fn add_dialer_to_socket<Protocol>(
     socket: &Socket<Protocol>,
     url: &CStr,

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -264,9 +264,15 @@ pub(crate) async fn add_dialer_to_socket(
                 // so the borrow checker prevents the socket from being closed out from under
                 // us. the only way to reach `ECLOSED` here is therefore: the dial future was
                 // dropped, the worker detached, and the caller subsequently dropped the
-                // `Socket`. in that case nobody is listening for our return value, so map
-                // this like `ECANCELED`.
-                tracing::warn!("socket closed after dial future was dropped");
+                // `Socket`. concretely: the future is most commonly dropped by `select!` /
+                // `tokio::time::timeout` cancellation; that releases the `&'socket self`
+                // borrow, which lets the caller drop the `Socket`, whose `Drop` impl calls
+                // `nng_socket_close` and so closes the socket under the still-running detached
+                // worker. note this does *not* involve a panic or `nng_fini`/`deinit_nng`
+                // tearing down the runtime — that path returns `ESTOPPED` and is handled
+                // below. in this case nobody is listening for our return value, so map this
+                // like `ECANCELED`.
+                tracing::debug!("socket closed after dial future was dropped");
                 Err(io::Error::from(AioError::Cancelled))
             }
             err if err == ErrorCode::ESTOPPED as u32 => {
@@ -290,7 +296,7 @@ pub(crate) async fn add_dialer_to_socket(
                 // I/O operation on the socket is cancelled by nng, and thus we get that error.
                 // we don't need to _do_ anything with it though, since we _know_ the caller has
                 // gone away (and thus doesn't care about our return value).
-                tracing::warn!("socket dropped while (now-cancelled) dial future still running");
+                tracing::debug!("socket dropped while (now-cancelled) dial future still running");
                 Err(io::Error::from(AioError::Cancelled))
             }
             err if err == ErrorCode::EAGAIN as u32 => {

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -96,8 +96,8 @@ pub(crate) unsafe fn create_socket<Protocol: core::fmt::Debug>(
 }
 
 /// Adds a listener to an existing socket.
-pub(crate) async fn add_listener_to_socket(
-    socket: nng_sys::nng_socket,
+pub(crate) async fn add_listener_to_socket<Protocol>(
+    socket: &Socket<Protocol>,
     url: &CStr,
     pre_start: impl FnOnce(nng_sys::nng_listener) -> io::Result<()>,
 ) -> io::Result<nng_sys::nng_listener> {
@@ -105,7 +105,7 @@ pub(crate) async fn add_listener_to_socket(
 
     // SAFETY: listener pointer is valid for writing, socket is valid, addr is valid C string.
     let errno =
-        unsafe { nng_sys::nng_listener_create(listener.as_mut_ptr(), socket, url.as_ptr()) };
+        unsafe { nng_sys::nng_listener_create(listener.as_mut_ptr(), socket.socket, url.as_ptr()) };
     match u32::try_from(errno).expect("errno is never negative") {
         0 => {}
         err if err == ErrorCode::ENOMEM as u32 => {

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -135,9 +135,10 @@ pub(crate) async fn add_listener_to_socket(
         let errno = unsafe { nng_sys::nng_listener_close(listener) };
         match u32::try_from(errno).expect("errno is never negative") {
             0 => {}
-            err if err == ErrorCode::ECLOSED as u32 => {
-                unreachable!("the listener handle is valid");
-            }
+            // the listener/socket was already closed (e.g. the nng runtime was torn down via
+            // the `unsafe` `deinit_nng`/`nng_fini`); there is nothing left to clean up, and we
+            // return the pre_start error below regardless.
+            err if err == ErrorCode::ECLOSED as u32 => {}
             errno => {
                 unreachable!(
                     "nng_listener_close documentation claims errno {errno} is never returned"
@@ -151,7 +152,16 @@ pub(crate) async fn add_listener_to_socket(
     match u32::try_from(errno).expect("errno is never negative") {
         0 => {}
         err if err == ErrorCode::ECLOSED as u32 => {
-            unreachable!("the listener handle is valid");
+            // the socket (and thus this listener) was closed out from under us. unlike the
+            // dialer, `add_listener_to_socket` is fully synchronous — no `spawn_blocking`, no
+            // `await` — so there is no dropped-future path here. the only way to reach `ECLOSED`
+            // is a teardown of the nng runtime via the `unsafe` `deinit_nng`/`nng_fini` while
+            // the socket was still open. surface the real error to the caller, who is still
+            // awaiting the result.
+            tracing::warn!("socket closed during listener start");
+            return Err(io::Error::from(AioError::Operation(ErrorKind::NngError(
+                ErrorCode::ECLOSED,
+            ))));
         }
         err if err == ErrorCode::ESTATE as u32 => {
             unreachable!("the listener is not already started");

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -194,8 +194,8 @@ pub(crate) async fn add_listener_to_socket(
 /// # Safety
 ///
 /// The socket must be a valid, open NNG socket.
-pub(crate) async fn add_dialer_to_socket(
-    socket: nng_sys::nng_socket,
+pub(crate) async fn add_dialer_to_socket<Protocol>(
+    socket: &Socket<Protocol>,
     url: &CStr,
     pre_start: impl FnOnce(nng_sys::nng_dialer) -> io::Result<()>,
 ) -> io::Result<nng_sys::nng_dialer> {
@@ -206,7 +206,8 @@ pub(crate) async fn add_dialer_to_socket(
     let mut dialer = MaybeUninit::<nng_sys::nng_dialer>::uninit();
 
     // SAFETY: dialer pointer is valid for writing, socket is valid, and addr is valid C string.
-    let errno = unsafe { nng_sys::nng_dialer_create(dialer.as_mut_ptr(), socket, url.as_ptr()) };
+    let errno =
+        unsafe { nng_sys::nng_dialer_create(dialer.as_mut_ptr(), socket.socket, url.as_ptr()) };
     match u32::try_from(errno).expect("errno is never negative") {
         0 => {}
         err if err == ErrorCode::ENOMEM as u32 => {
@@ -260,20 +261,21 @@ pub(crate) async fn add_dialer_to_socket(
         match u32::try_from(errno).expect("errno is never negative") {
             0 => Ok(()),
             err if err == ErrorCode::ECLOSED as u32 => {
-                // the socket was closed underneath the dial. while the dial future is still
-                // awaiting it holds `&'socket self`, and `Socket::drop` needs `&mut self`,
-                // so the borrow checker prevents the socket from being closed out from under
-                // us. the only way to reach `ECLOSED` here is therefore: the dial future was
-                // dropped, the worker detached, and the caller subsequently dropped the
-                // `Socket`. concretely: the future is most commonly dropped by `select!` /
-                // `tokio::time::timeout` cancellation; that releases the `&'socket self`
-                // borrow, which lets the caller drop the `Socket`, whose `Drop` impl calls
+                // the socket was closed underneath the dial. this function borrows the socket
+                // as `&Socket` for the lifetime of the returned future, and
+                // `Socket::drop` needs `&mut self`, so the borrow checker prevents the socket
+                // from being closed out from under us while the future is alive. the only way
+                // to reach `ECLOSED` here is therefore: the dial future was dropped, the
+                // `spawn_blocking` worker detached, and the caller subsequently dropped the
+                // `Socket`. the future can be dropped by any cancellation (`select!`,
+                // `tokio::time::timeout`, `FuturesUnordered`, ...); that releases the borrow,
+                // which lets the caller drop the `Socket`, whose `Drop` impl calls
                 // `nng_socket_close` and so closes the socket under the still-running detached
                 // worker. note this does *not* involve a panic or `nng_fini`/`deinit_nng`
                 // tearing down the runtime — that path returns `ESTOPPED` and is handled
                 // below. in this case nobody is listening for our return value, so map this
                 // like `ECANCELED`.
-                tracing::debug!("socket closed after dial future was dropped");
+                tracing::warn!("socket closed after dial future was dropped");
                 Err(io::Error::from(AioError::Cancelled))
             }
             err if err == ErrorCode::ESTOPPED as u32 => {
@@ -297,7 +299,7 @@ pub(crate) async fn add_dialer_to_socket(
                 // I/O operation on the socket is cancelled by nng, and thus we get that error.
                 // we don't need to _do_ anything with it though, since we _know_ the caller has
                 // gone away (and thus doesn't care about our return value).
-                tracing::debug!("socket dropped while (now-cancelled) dial future still running");
+                tracing::warn!("socket dropped while (now-cancelled) dial future still running");
                 Err(io::Error::from(AioError::Cancelled))
             }
             err if err == ErrorCode::EAGAIN as u32 => {

--- a/anng/src/protocols/mod.rs
+++ b/anng/src/protocols/mod.rs
@@ -232,9 +232,10 @@ pub(crate) async fn add_dialer_to_socket(
         let errno = unsafe { nng_sys::nng_dialer_close(dialer) };
         match u32::try_from(errno).expect("errno is never negative") {
             0 => {}
-            err if err == ErrorCode::ECLOSED as u32 => {
-                unreachable!("the dialer handle is valid");
-            }
+            // the dialer/socket was already closed (e.g. the nng runtime was torn down via
+            // the `unsafe` `deinit_nng`/`nng_fini`); there is nothing left to clean up, and we
+            // return the pre_start error below regardless.
+            err if err == ErrorCode::ECLOSED as u32 => {}
             errno => {
                 unreachable!(
                     "nng_dialer_close documentation claims errno {errno} is never returned"
@@ -292,7 +293,7 @@ pub(crate) async fn add_dialer_to_socket(
             }
             err if err == ErrorCode::ECANCELED as u32 => {
                 // this can happen if the dial future is dropped (such as if the future is
-                // cancelled), and that _also_ drops the referenced socket. if this occurrs, any
+                // cancelled), and that _also_ drops the referenced socket. if this occurs, any
                 // I/O operation on the socket is cancelled by nng, and thus we get that error.
                 // we don't need to _do_ anything with it though, since we _know_ the caller has
                 // gone away (and thus doesn't care about our return value).


### PR DESCRIPTION
`Socket::dial` runs `nng_dialer_start` inside `spawn_blocking`. Dropping the dial future (e.g. via `tokio::select!`) detaches the worker and releases the `&'socket self` borrow, letting the caller drop its `Socket`. The resulting `nng_socket_close` races the dial and surfaces as `NNG_ECLOSED`, `NNG_ECANCELED`, or `NNG_ESTOPPED` depending on timing. The `ECLOSED` arm and the catch-all (which caught `ESTOPPED`) were `unreachable!`, panicking the detached worker.

Keep `ECANCELED` mapped to `AioError::Cancelled` (the dial future was actually dropped), but map `ECLOSED` (socket closed via another path) and `ESTOPPED` (nng_fini tearing down the runtime) to the real `AioError::Operation` error, consistent with aio.rs mapping `ECLOSED` to `BrokenPipe`. For the dropped-future case tokio discards the return value, so surfacing the genuine error is harmless there.

Also forward `NNG_ECONNABORTED` and `NNG_ETIMEDOUT`: `dialer_connect_cb` in nng's `src/core/dialer.c` propagates the transport connect result to the synchronous waiter and calls these out explicitly in its default branch. Neither was listed in our match, so they would trip the catch-all `unreachable!` and panic the worker. Surface both as `AioError::Operation` alongside the other transport errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialer and listener startup and shutdown so socket closure or runtime teardown no longer causes panics.
  * Cleanup now handles cancelled or interrupted connection attempts more gracefully.
  * Refined connection error handling to distinguish timeouts, cancellations, and aborted connections.
  * Enhanced diagnostic warnings for rapid connect/disconnect scenarios, making these issues easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->