### PR TITLE
nng: fix doc warnings and initialize NNG before opening sockets

### DIFF
--- a/nng/src/lib.rs
+++ b/nng/src/lib.rs
@@ -172,7 +172,7 @@ pub struct Params {
     /// The number of threads to use for tasks.
     ///
     /// These tasks are principally for callback completion. This number cannot
-    /// exceed [`Init::max_task_threads`].
+    /// exceed [`Params::max_task_threads`].
     pub num_task_threads: Option<NonZeroU16>,
 
     /// The maximum number of threads to use for tasks.
@@ -186,7 +186,7 @@ pub struct Params {
     ///
     /// Using a larger value will reduce contention on some common locks, and
     /// may improve performance. This number cannot exceed
-    /// [`Init::max_expire_threads`].
+    /// [`Params::max_expire_threads`].
     pub num_expire_threads: Option<NonZeroU16>,
 
     /// The maximum number of threads used for expiring operations.
@@ -199,7 +199,7 @@ pub struct Params {
     /// The number of threads to use for performing I/O.
     ///
     /// Not all configurations will support this. Cannot exceed
-    /// [`Init::max_poller_threads`].
+    /// [`Params::max_poller_threads`].
     pub num_poller_threads: Option<NonZeroU16>,
 
     /// The maximum number of threads to use for performing I/O.

--- a/nng/src/socket.rs
+++ b/nng/src/socket.rs
@@ -52,6 +52,14 @@ impl Socket {
     /// [`NotSupported`]: enum.Error.html#variant.NotSupported
     /// [`OutOfMemory`]: enum.Error.html#variant.OutOfMemory
     pub fn new(t: Protocol) -> Result<Socket> {
+        // NNG v2 requires the library to be initialized before any socket is
+        // opened. Calling `nng_init(NULL)` is idempotent and applies default
+        // tuning when no params have been supplied yet.
+        // SAFETY: Null pointers are valid.
+        unsafe {
+            nng_sys::nng_init(ptr::null());
+        }
+
         // Create the uninitialized nng_socket
         let mut socket = nng_sys::nng_socket::NNG_SOCKET_INITIALIZER;
 
@@ -73,10 +81,6 @@ impl Socket {
         };
 
         rv2res!(rv, {
-            // SAFETY: Null pointers are valid.
-            unsafe {
-                nng_sys::nng_init(ptr::null());
-            }
             Socket {
                 inner: Arc::new(Inner {
                     handle: socket,


### PR DESCRIPTION
Two fixes surfaced by `cargo doc` and `cargo test --doc`:

* `Params` fields referenced themselves as `Init::*` in their docs, producing broken intra-doc links. Renamed to `Params::*`.
* `Socket::new` opened the protocol socket before calling `nng_init`. NNG v2 requires the library to be initialized first; the previous ordering segfaulted on the very first `Socket::new` call and caused the crate's lib doc test to abort with SIGSEGV.