### PR TITLE
nng-sys: update nng to v1.12.0 (stable)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "nng-sys"
-version = "0.3.0+1.11.0"
+version = "0.3.1+1.12.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/anng/Cargo.toml
+++ b/anng/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.41"
 lazy_static = { version = "1.5.0", optional = true }
 
 [dependencies.nng-sys]
-version = "0.3.0"
+version = "0.3.1"
 path = "../nng-sys"
 default-features = false
 

--- a/nng-sys/Cargo.toml
+++ b/nng-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nng-sys"
-version = "0.3.0+1.11.0"
+version = "0.3.1+1.12.0"
 authors = [
     "Nathan Kent <nate@nkent.net>",
     "Jake W <jeikabu@gmail.com>",

--- a/nng-sys/README.md
+++ b/nng-sys/README.md
@@ -70,10 +70,10 @@ There is no fallback to a vendored version.
 
 This crate uses the format `<crate version>+<nng version>` following [Semantic Versioning 2.0.0](https://semver.org/#spec-item-10).
 
-**Example:** `0.3.0+1.11.0`
+**Example:** `0.3.0+1.12.0`
 
 - `0.3.0` - The crate's own semantic version, indicating API compatibility
-- `+1.11.0` - Build metadata showing the wrapped NNG library version
+- `+1.12.0` - Build metadata showing the wrapped NNG library version
 
 ### How Versions Change
 

--- a/nng/Cargo.toml
+++ b/nng/Cargo.toml
@@ -27,6 +27,6 @@ ffi-module = []
 log = "0.4.28"
 
 [dependencies.nng-sys]
-version = "0.3.0"
+version = "0.3.1"
 default-features = false
 path = "../nng-sys"


### PR DESCRIPTION
Move the vendored nng submodule from 84aa701 to 45f8116, which upstream
tagged v1.12.0, and bump the crate accordingly: `0.3.0+1.11.0` -> `0.3.1+1.12.0`. The patch bump follows the versioning scheme documented in nng-sys/README.md -- Cargo ignores the `+<nng version>` build metadata, so `0.3.0+1.12.0` could not coexist with the already published `0.3.0+1.11.0`. `nng` and `anng` raise their `nng-sys` requirement to `0.3.1` so that a `-Zminimal-versions` resolve also picks up the newer nng.

Notable upstream changes:

- fix(stable): sendmsg/readv EINVAL for large iov on macOS and Windows (#2244)
- http server: add modern MIME types to static content map (#2247)
- aio: task_abort was a mistake (fixes #2208)
- extend possible errors from nng_pipe_get with ENOENT
- tests/ci: switch http client test to httpbin, drop mbedTLS on darwin

Note the confusing part: upstream did not bump the version macros for this release. At tag v1.12.0, include/nng/nng.h still declares

    #define NNG_MAJOR_VERSION 1
    #define NNG_MINOR_VERSION 11
    #define NNG_PATCH_VERSION 0

The last bump was commit 84aa701 ("Bunch version to 1.11."), which is exactly the commit we were previously pointing at. As a result nng_version(), the NNG_ABI_VERSION derived from those macros by CMakeLists.txt, and the pkg-config/CPack package version all still report 1.11.0 for what is really 1.12.0. The +1.12.0 build metadata here therefore names the upstream tag, not what the library reports about itself at runtime. Harmless for us since we pin by submodule commit, but worth knowing when the two disagree. See also https://github.com/nanomsg/nng/issues/2301.