### PR TITLE
anng: fix: resolve listen/dial ordering races in doctests

### DIFF
--- a/anng/src/lib.rs
+++ b/anng/src/lib.rs
@@ -21,9 +21,9 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! // Server side
-//! tokio::spawn(async {
-//!     let socket = reqrep0::Rep0::listen(c"inproc://quick-start").await?;
+//! // Server side - listen before the client dials
+//! let socket = reqrep0::Rep0::listen(c"inproc://quick-start").await?;
+//! tokio::spawn(async move {
 //!     let mut ctx = socket.context();
 //!     loop {
 //!         let (request, responder) = ctx.receive().await?;
@@ -36,7 +36,6 @@
 //!     }
 //!     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
 //! });
-//! # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 //!
 //! // Client side
 //! let socket = reqrep0::Req0::dial(c"inproc://quick-start").await?;
@@ -61,9 +60,9 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! // Publisher
-//! tokio::spawn(async {
-//!     let mut socket = pubsub0::Pub0::listen(c"inproc://pubsub").await?;
+//! // Publisher - listen before the subscriber dials
+//! let mut socket = pubsub0::Pub0::listen(c"inproc://pubsub").await?;
+//! tokio::spawn(async move {
 //!     loop {
 //!         let mut msg = Message::with_capacity(100);
 //!         write!(&mut msg, "news: Breaking news!")?;
@@ -73,7 +72,6 @@
 //!     }
 //!     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
 //! });
-//! # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 //!
 //! // Subscriber
 //! let socket = pubsub0::Sub0::dial(c"inproc://pubsub").await?;

--- a/anng/src/protocols/pipeline0.rs
+++ b/anng/src/protocols/pipeline0.rs
@@ -36,17 +36,17 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! // Pusher (work distributor), in one task
-//! # tokio::spawn(async {
+//! // The pusher must listen before the puller dials, otherwise the dial is refused.
 //! let mut push_socket = pipeline0::Push0::listen(c"inproc://work-queue").await?;
 //!
-//! let mut task = Message::with_capacity(100);
-//! write!(&mut task, "process_data(42)")?;
-//! // TODO: In production, handle error and retry with returned message
-//! push_socket.push(task).await.unwrap();
-//! # Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
-//! # });
-//! # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+//! // Pusher (work distributor), in one task
+//! tokio::spawn(async move {
+//!     let mut task = Message::with_capacity(100);
+//!     write!(&mut task, "process_data(42)")?;
+//!     // TODO: In production, handle error and retry with returned message
+//!     push_socket.push(task).await.unwrap();
+//!     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+//! });
 //!
 //! // Puller (worker), in another task
 //! let mut pull_socket = pipeline0::Pull0::dial(c"inproc://work-queue").await?;
@@ -65,6 +65,9 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! // The distributor must listen before any worker dials
+//! let mut distributor = pipeline0::Push0::listen(c"inproc://pipeline-loadbalance-demo").await?;
+//!
 //! // Start multiple workers
 //! for worker_id in 0..2 {
 //!     tokio::spawn(async move {
@@ -80,7 +83,6 @@
 //! }
 //!
 //! // Distribute work
-//! let mut distributor = pipeline0::Push0::listen(c"inproc://pipeline-loadbalance-demo").await?;
 //! for i in 0..2 {
 //!     let mut task = Message::with_capacity(50);
 //!     write!(&mut task, "task_{}", i)?;

--- a/anng/src/protocols/pubsub0.rs
+++ b/anng/src/protocols/pubsub0.rs
@@ -31,20 +31,20 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! // Publisher, in one task
-//! # tokio::spawn(async {
+//! // The publisher must listen before the subscriber dials, otherwise the dial is refused.
 //! let mut pub_socket = pubsub0::Pub0::listen(c"inproc://news").await?;
 //!
-//! # loop {
-//! let mut msg = Message::with_capacity(100);
-//! write!(&mut msg, "news.sports: Team wins!")?;
-//! // TODO: In production, handle error and retry with returned message
-//! pub_socket.publish(msg).await.unwrap();
-//! # tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-//! # }
-//! # Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
-//! # });
-//! # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+//! // Publisher, in one task
+//! tokio::spawn(async move {
+//! #   loop {
+//!     let mut msg = Message::with_capacity(100);
+//!     write!(&mut msg, "news.sports: Team wins!")?;
+//!     // TODO: In production, handle error and retry with returned message
+//!     pub_socket.publish(msg).await.unwrap();
+//! #   tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+//! #   }
+//!     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+//! });
 //!
 //! // Subscriber, in another task
 //! let sub_socket = pubsub0::Sub0::dial(c"inproc://news").await?;
@@ -65,8 +65,8 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! # tokio::spawn(async {
 //! # let mut pub_socket = pubsub0::Pub0::listen(c"inproc://pubsub-topic-filter-demo").await?;
+//! # tokio::spawn(async move {
 //! # loop {
 //! #     let mut msg = Message::with_capacity(100);
 //! #     write!(&mut msg, "news.sports: Team wins!")?;
@@ -75,7 +75,6 @@
 //! # }
 //! # Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
 //! # });
-//! # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 //! let sub_socket = pubsub0::Sub0::dial(c"inproc://pubsub-topic-filter-demo").await?;
 //! let mut sub = sub_socket.context();
 //!
@@ -129,8 +128,8 @@ use std::io;
 /// # use std::io::Write;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-/// # tokio::spawn(async {
-/// #     let mut pub_socket = Pub0::listen(c"inproc://sub0-usage-doctest").await?;
+/// # let mut pub_socket = Pub0::listen(c"inproc://sub0-usage-doctest").await?;
+/// # tokio::spawn(async move {
 /// #     loop {
 /// #         let mut msg = anng::Message::with_capacity(100);
 /// #         write!(&mut msg, "news.breaking: Important update!")?;
@@ -139,7 +138,6 @@ use std::io;
 /// #     }
 /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
 /// # });
-/// # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 /// // Connect to publisher
 /// let socket = Sub0::dial(c"inproc://sub0-usage-doctest").await?;
 /// let mut ctx = socket.context();
@@ -219,8 +217,8 @@ impl<'socket> ContextfulSocket<'socket, Sub0> {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    /// # tokio::spawn(async {
-    /// #     let mut pub_socket = pubsub0::Pub0::listen(c"inproc://next-doctest-feed").await?;
+    /// # let mut pub_socket = pubsub0::Pub0::listen(c"inproc://next-doctest-feed").await?;
+    /// # tokio::spawn(async move {
     /// #     loop {
     /// #         let mut msg = anng::Message::with_capacity(100);
     /// #         write!(&mut msg, "news.sports: Team wins championship!")?;
@@ -229,7 +227,6 @@ impl<'socket> ContextfulSocket<'socket, Sub0> {
     /// #     }
     /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     /// # });
-    /// # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     /// let socket = pubsub0::Sub0::dial(c"inproc://next-doctest-feed").await?;
     /// let mut sub = socket.context();
     ///
@@ -314,8 +311,8 @@ impl<'socket> ContextfulSocket<'socket, Sub0> {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    /// # tokio::spawn(async {
-    /// #     let mut pub_socket = pubsub0::Pub0::listen(c"inproc://sub0-disable-filtering-demo").await?;
+    /// # let mut pub_socket = pubsub0::Pub0::listen(c"inproc://sub0-disable-filtering-demo").await?;
+    /// # tokio::spawn(async move {
     /// #     loop {
     /// #         let mut msg = anng::Message::with_capacity(100);
     /// #         write!(&mut msg, "test message")?;
@@ -324,7 +321,6 @@ impl<'socket> ContextfulSocket<'socket, Sub0> {
     /// #     }
     /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     /// # });
-    /// # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     /// let socket = pubsub0::Sub0::dial(c"inproc://sub0-disable-filtering-demo").await?;
     /// let mut sub = socket.context();
     ///

--- a/anng/src/protocols/reqrep0.rs
+++ b/anng/src/protocols/reqrep0.rs
@@ -29,20 +29,22 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! // Server, in one task
-//! # tokio::spawn(async {
+//! // The server must listen before the client dials, otherwise the dial is refused.
 //! let socket = reqrep0::Rep0::listen(c"inproc://demo").await?;
-//! let mut ctx = socket.context();
 //!
-//! let (request, responder) = ctx.receive().await?;
-//! println!("Got request: {:?}", request.as_slice());
+//! // Server, in one task
+//! tokio::spawn(async move {
+//!     let mut ctx = socket.context();
 //!
-//! let mut reply = Message::with_capacity(100);
-//! write!(&mut reply, "Hello back!")?;
-//! // TODO: In production, handle error and retry with returned responder and message
-//! responder.reply(reply).await.unwrap();
-//! # Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
-//! # });
+//!     let (request, responder) = ctx.receive().await?;
+//!     println!("Got request: {:?}", request.as_slice());
+//!
+//!     let mut reply = Message::with_capacity(100);
+//!     write!(&mut reply, "Hello back!")?;
+//!     // TODO: In production, handle error and retry with returned responder and message
+//!     responder.reply(reply).await.unwrap();
+//!     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+//! });
 //!
 //! // Client, in another (concurrent) task
 //! let socket = reqrep0::Req0::dial(c"inproc://demo").await?;
@@ -115,11 +117,11 @@ use std::{future::Future, io};
 /// # use std::io::Write;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-/// # tokio::spawn(async {
-/// #     let socket = Rep0::listen(c"inproc://req0-usage-doctest").await?;
-/// #     let mut ctx = socket.context();
+/// # let replier = Rep0::listen(c"inproc://req0-usage-doctest").await?;
+/// # tokio::spawn(async move {
+/// #     let mut ctx = replier.context();
 /// #     loop {
-/// #         let (request, responder) = ctx.receive().await?;
+/// #         let (_request, responder) = ctx.receive().await?;
 /// #         let reply = anng::Message::from(&b"Reply from server"[..]);
 /// #         responder.reply(reply).await.unwrap();
 /// #     }
@@ -303,11 +305,12 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    /// # tokio::spawn(async {
-    /// #     let socket = reqrep0::Rep0::listen(c"inproc://request-doctest").await?;
-    /// #     let mut ctx = socket.context();
+    /// # // The replier must listen before the requester dials.
+    /// # let replier = reqrep0::Rep0::listen(c"inproc://request-doctest").await?;
+    /// # tokio::spawn(async move {
+    /// #     let mut ctx = replier.context();
     /// #     loop {
-    /// #         let (request, responder) = ctx.receive().await?;
+    /// #         let (_request, responder) = ctx.receive().await?;
     /// #         let mut reply = Message::with_capacity(100);
     /// #         write!(&mut reply, "Hello back!")?;
     /// #         responder.reply(reply).await.unwrap();
@@ -387,6 +390,10 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
 /// # use anng::protocols::reqrep0::{Rep0, Req0};
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// // Listen for client connections
+/// let socket = Rep0::listen(c"inproc://rep0-usage-demo").await?;
+/// let mut ctx = socket.context();
+/// # // Only dial once the listener above is up, otherwise the dial is refused.
 /// # tokio::spawn(async {
 /// #     let socket = Req0::dial(c"inproc://rep0-usage-demo").await?;
 /// #     let mut ctx = socket.context();
@@ -395,9 +402,6 @@ impl<'socket> ContextfulSocket<'socket, Req0> {
 /// #     let _reply = reply_future.await?;
 /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
 /// # });
-/// // Listen for client connections
-/// let socket = Rep0::listen(c"inproc://rep0-usage-demo").await?;
-/// let mut ctx = socket.context();
 ///
 /// // Handle request-reply cycle
 /// let (request, responder) = ctx.receive().await?;
@@ -563,6 +567,9 @@ impl<'socket> ContextfulSocket<'socket, Rep0> {
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// let socket = reqrep0::Rep0::listen(c"inproc://service").await?;
+/// let mut ctx = socket.context();
+/// # // Only dial once the listener above is up, otherwise the dial is refused.
 /// # tokio::spawn(async {
 /// #     let socket = reqrep0::Req0::dial(c"inproc://service").await?;
 /// #     let mut ctx = socket.context();
@@ -571,8 +578,6 @@ impl<'socket> ContextfulSocket<'socket, Rep0> {
 /// #     let _reply = reply_future.await?;
 /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
 /// # });
-/// let socket = reqrep0::Rep0::listen(c"inproc://service").await?;
-/// let mut ctx = socket.context();
 ///
 /// let (request, responder) = ctx.receive().await?;
 ///
@@ -633,6 +638,9 @@ impl Responder<'_, '_> {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let socket = reqrep0::Rep0::listen(c"inproc://replies").await?;
+    /// let mut ctx = socket.context();
+    /// # // Only dial once the listener above is up, otherwise the dial is refused.
     /// # tokio::spawn(async {
     /// #     let socket = reqrep0::Req0::dial(c"inproc://replies").await?;
     /// #     let mut ctx = socket.context();
@@ -641,8 +649,6 @@ impl Responder<'_, '_> {
     /// #     let _reply = reply_future.await?;
     /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     /// # });
-    /// let socket = reqrep0::Rep0::listen(c"inproc://replies").await?;
-    /// let mut ctx = socket.context();
     ///
     /// let (request, responder) = ctx.receive().await?;
     ///

--- a/anng/src/protocols/survey0.rs
+++ b/anng/src/protocols/survey0.rs
@@ -33,32 +33,33 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! // Surveyor, in one task
-//! # tokio::spawn(async {
+//! // The surveyor must listen before the respondent dials, otherwise the dial is refused.
 //! let socket = survey0::Surveyor0::listen(c"inproc://survey").await?;
-//! let mut ctx = socket.context();
 //!
-//! loop {
-//!     let mut survey = Message::with_capacity(100);
-//!     write!(&mut survey, "Who wants to be leader?")?;
+//! // Surveyor, in one task
+//! tokio::spawn(async move {
+//!     let mut ctx = socket.context();
 //!
-//!     let timeout = std::time::Duration::from_millis(200);
-//!     // TODO: In production, handle error and retry with returned message
-//!     let mut responses = ctx.survey(survey, timeout).await.unwrap();
-//!     // Collect responses for the configured timeout period
-//!     while let Some(response) = responses.next().await {
-//!         match response {
-//!             Ok(msg) => println!("Response: {:?}", msg.as_slice()),
-//!             Err(e) => {
-//!                 println!("Survey error: {:?}", e);
-//!                 break;
+//!     loop {
+//!         let mut survey = Message::with_capacity(100);
+//!         write!(&mut survey, "Who wants to be leader?")?;
+//!
+//!         let timeout = std::time::Duration::from_millis(200);
+//!         // TODO: In production, handle error and retry with returned message
+//!         let mut responses = ctx.survey(survey, timeout).await.unwrap();
+//!         // Collect responses for the configured timeout period
+//!         while let Some(response) = responses.next().await {
+//!             match response {
+//!                 Ok(msg) => println!("Response: {:?}", msg.as_slice()),
+//!                 Err(e) => {
+//!                     println!("Survey error: {:?}", e);
+//!                     break;
+//!                 }
 //!             }
 //!         }
 //!     }
-//! }
-//! # Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
-//! # });
-//! # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+//!     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+//! });
 //!
 //! // Respondent, in another task
 //! let socket = survey0::Respondent0::dial(c"inproc://survey").await?;
@@ -237,19 +238,20 @@ impl<'socket> ContextfulSocket<'socket, Surveyor0> {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// let socket = survey0::Surveyor0::listen(c"inproc://vote").await?;
+    /// let mut ctx = socket.context();
+    /// # // Only dial once the listener above is up, otherwise the dial is refused.
     /// # tokio::spawn(async {
     /// #     let socket = survey0::Respondent0::dial(c"inproc://vote").await?;
     /// #     let mut ctx = socket.context();
     /// #     loop {
-    /// #         let (survey, responder) = ctx.next_survey().await?;
+    /// #         let (_survey, responder) = ctx.next_survey().await?;
     /// #         let mut response = Message::with_capacity(50);
     /// #         write!(&mut response, "Yes")?;
     /// #         responder.respond(response).await.unwrap();
     /// #     }
     /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     /// # });
-    /// let socket = survey0::Surveyor0::listen(c"inproc://vote").await?;
-    /// let mut ctx = socket.context();
     ///
     /// let mut survey = Message::with_capacity(100);
     /// write!(&mut survey, "Should we upgrade to version 2.0?")?;
@@ -317,18 +319,19 @@ impl SurveyResponses<'_, '_> {
     /// # use std::time::Duration;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # let socket = survey0::Surveyor0::listen(c"inproc://test").await?;
+    /// # let mut ctx = socket.context();
+    /// # // Only dial once the listener above is up, otherwise the dial is refused.
     /// # tokio::spawn(async {
     /// #     let socket = survey0::Respondent0::dial(c"inproc://test").await?;
     /// #     let mut ctx = socket.context();
     /// #     loop {
-    /// #         let (survey, responder) = ctx.next_survey().await?;
+    /// #         let (_survey, responder) = ctx.next_survey().await?;
     /// #         let response = Message::from(&b"test response"[..]);
     /// #         responder.respond(response).await.unwrap();
     /// #     }
     /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     /// # });
-    /// # let socket = survey0::Surveyor0::listen(c"inproc://test").await?;
-    /// # let mut ctx = socket.context();
     /// # let survey = Message::from(&b"test"[..]);
     /// let timeout = Duration::from_secs(1);
     /// let mut responses = ctx.survey(survey, timeout).await.unwrap();
@@ -427,9 +430,9 @@ impl SurveyResponses<'_, '_> {
 /// # use std::io::Write;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-/// # tokio::spawn(async {
-/// #     let socket = Surveyor0::listen(c"inproc://respondent0-usage-doctest").await?;
-/// #     let mut ctx = socket.context();
+/// # let surveyor = Surveyor0::listen(c"inproc://respondent0-usage-doctest").await?;
+/// # tokio::spawn(async move {
+/// #     let mut ctx = surveyor.context();
 /// #     loop {
 /// #         let mut survey = Message::with_capacity(50);
 /// #         write!(&mut survey, "health-check")?;
@@ -439,7 +442,6 @@ impl SurveyResponses<'_, '_> {
 /// #     }
 /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
 /// # });
-/// # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 /// // Connect to surveyor
 /// let socket = Respondent0::dial(c"inproc://respondent0-usage-doctest").await?;
 /// let mut ctx = socket.context();
@@ -522,9 +524,9 @@ impl<'socket> ContextfulSocket<'socket, Respondent0> {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    /// # tokio::spawn(async {
-    /// #     let socket = survey0::Surveyor0::listen(c"inproc://service-discovery").await?;
-    /// #     let mut ctx = socket.context();
+    /// # let surveyor = survey0::Surveyor0::listen(c"inproc://service-discovery").await?;
+    /// # tokio::spawn(async move {
+    /// #     let mut ctx = surveyor.context();
     /// #     loop {
     /// #         let mut survey = Message::with_capacity(50);
     /// #         write!(&mut survey, "health-check")?;
@@ -534,7 +536,6 @@ impl<'socket> ContextfulSocket<'socket, Respondent0> {
     /// #     }
     /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     /// # });
-    /// # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     /// let socket = survey0::Respondent0::dial(c"inproc://service-discovery").await?;
     /// let mut ctx = socket.context();
     ///
@@ -631,9 +632,9 @@ impl SurveyResponder<'_, '_> {
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    /// # tokio::spawn(async {
-    /// #     let socket = survey0::Surveyor0::listen(c"inproc://status").await?;
-    /// #     let mut ctx = socket.context();
+    /// # let surveyor = survey0::Surveyor0::listen(c"inproc://status").await?;
+    /// # tokio::spawn(async move {
+    /// #     let mut ctx = surveyor.context();
     /// #     loop {
     /// #         let survey = Message::from(&b"status check"[..]);
     /// #         let timeout = std::time::Duration::from_secs(1);
@@ -642,7 +643,6 @@ impl SurveyResponder<'_, '_> {
     /// #     }
     /// #     Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     /// # });
-    /// # tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     /// let socket = survey0::Respondent0::dial(c"inproc://status").await?;
     /// let mut ctx = socket.context();
     ///


### PR DESCRIPTION
CI hit "Connection refused" in the reqrep0 `request` doctest: it created the REP listener inside `tokio::spawn` and then dialed immediately from the main task. `dial()` starts the dialer synchronously with flag 0 rather than NNG_FLAG_NONBLOCK (see the nng_dialer_start_aio TODO in protocols::mod), so it fails outright instead of retrying when the endpoint does not exist yet. If the spawned task had not run yet, the dial lost the race.

Both orderings of this mistake were present across the crate. Fifteen doctests created the listener inside the spawned task and dialed from the main task. Another six did the reverse, spawning the dialer and calling `listen()` afterwards in the main task: reqrep0 (Rep0, Responder, Responder::reply), survey0 (survey, SurveyResponses::next) and the pipeline0 load-balancing example. The second shape fails worse, because the spawned task's ConnectionRefused is discarded along with its JoinHandle and the main task then blocks forever in `receive()` or `push()` rather than reporting an error. Since doctests are merged into a single binary and rustdoc applies no per-test timeout, one such hang wedges the whole `--doc` run until CI kills the job with no diagnostic.

Apply the transformation already used for bus0 in c399535 throughout: call `listen()` in the main task, before any `tokio::spawn`, and move only the peer side into the spawned task. `listen()` completes the endpoint setup before it returns, so a dial can no longer arrive first. No doctest in the crate now calls `listen()` at or after a spawn, in either direction.

This also removes seven `sleep(200ms)` calls that were papering over the race. The remaining sleeps are unrelated: 100ms pacing inside publisher loops (pub/sub drops messages with no attached subscriber, so the publisher must keep republishing until the subscriber attaches) and the 200ms pre-send delay in the bus0 example.

Finally, the module-level examples for pipeline0, pubsub0, reqrep0 and survey0 hid both the `tokio::spawn(...)` line and its closing brace behind `#`, so rustdoc rendered a server loop and a client running sequentially in one function, which deadlocks if copy-pasted. Make the spawn visible in all four, matching what the lib.rs examples already do, so the reason for the ordering is visible alongside the ordering itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated networking quick-start examples to establish listeners before connecting clients or workers.
  * Removed unnecessary startup delays from request/reply, publish/subscribe, pipeline, and survey examples.
  * Clarified task setup, message handling, and connection ordering for more reliable, understandable examples.
* **Bug Fixes**
  * Prevented connection-refused errors in in-process documentation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->