### PR TITLE
nng: bump version to 2.0.0-v2pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "nng"
-version = "1.0.1"
+version = "2.0.0-v2pre.1"
 dependencies = [
  "log",
  "nng-sys 0.4.0-v2pre.2+v2.0.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/nng/Cargo.toml
+++ b/nng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nng"
-version = "1.0.1"
+version = "2.0.0-v2pre.1"
 authors = ["Nathan Kent <nate@nkent.net>"]
 
 description = "A safe wrapper for NNG (Nanomsg v2)"


### PR DESCRIPTION
The 1.0.x line on crates.io (last release 1.0.1, 2021-12-08) is not
compatible with the current API. `cargo semver-checks` against the
published 1.0.1 baseline reports 5 major violations:

    - module_missing: the whole `nng::options` module tree is gone
    (`options`, `options::protocol{,::pair,::pubsub,::reqrep,::survey}`,
    `options::transport{,::ipc,::tcp,::tls,::websocket}`)
    - trait_missing: `options::{Options, Opt, GetOpt, SetOpt}`
    - enum_missing: all 33 option marker enums (`options::Raw`,
    `options::RecvTimeout`, `options::transport::tcp::NoDelay`, ...)
    - enum_variant_added: `SocketAddr::Abstract` on an exhaustive enum
    - feature_not_enabled_by_default: `build-nng` is no longer a default
    feature

Releasing any 1.x from this tree would therefore be a semver lie. Move
to 2.0.0, using the `-v2pre.N` prerelease series to match the nng-sys
versioning scheme while NNG v2 itself is still in alpha.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the crate version to the 2.0.0-v2pre.1 prerelease.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->